### PR TITLE
Implement directory selection and image scanning (Step 4)

### DIFF
--- a/image-gallery/package-lock.json
+++ b/image-gallery/package-lock.json
@@ -8,6 +8,8 @@
       "name": "image-gallery",
       "version": "0.0.0",
       "dependencies": {
+        "@tauri-apps/plugin-dialog": "^2.5.0",
+        "@tauri-apps/plugin-fs": "^2.4.5",
         "@tauri-apps/plugin-sql": "^2.3.1",
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
@@ -1889,6 +1891,24 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.5.0.tgz",
+      "integrity": "sha512-I0R0ygwRd9AN8Wj5GnzCogOlqu2+OWAtBd0zEC4+kQCI32fRowIyuhPCBoUv4h/lQt2bM39kHlxPHD5vDcFjiA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-fs": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.5.tgz",
+      "integrity": "sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-sql": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.1.tgz",
@@ -3140,7 +3160,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3242,7 +3261,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },

--- a/image-gallery/package.json
+++ b/image-gallery/package.json
@@ -13,6 +13,8 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@tauri-apps/plugin-dialog": "^2.5.0",
+    "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-sql": "^2.3.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",

--- a/image-gallery/src-tauri/Cargo.lock
+++ b/image-gallery/src-tauri/Cargo.lock
@@ -91,8 +91,11 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-sql",
+ "walkdir",
 ]
 
 [[package]]
@@ -741,6 +744,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -3059,6 +3064,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,6 +4101,46 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.10+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05416b57601eca8666b5ec4186f5b1dc826ed35263b4797ad6641e58da6bc6c3"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.17",
+ "toml 0.9.10+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/image-gallery/src-tauri/Cargo.toml
+++ b/image-gallery/src-tauri/Cargo.toml
@@ -25,3 +25,6 @@ tauri = { version = "2.9.5", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-sql = { version = "2.3.1", features = ["sqlite"] }
 dirs = "6.0.0"
+tauri-plugin-dialog = "2.5.0"
+tauri-plugin-fs = "2.4.5"
+walkdir = "2.5.0"

--- a/image-gallery/src-tauri/src/commands.rs
+++ b/image-gallery/src-tauri/src/commands.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[tauri::command]
 pub async fn initialize_database() -> Result<String, String> {
     crate::db::init_db().await?;
@@ -8,4 +10,55 @@ pub async fn initialize_database() -> Result<String, String> {
 pub fn get_database_path() -> Result<String, String> {
     let db_path = crate::db::get_db_path()?;
     Ok(db_path.to_string_lossy().to_string())
+}
+
+/**
+ * ディレクトリ選択ダイアログを表示します
+ */
+#[tauri::command]
+pub async fn select_directory(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let folder = app
+        .dialog()
+        .file()
+        .blocking_pick_folder();
+
+    match folder {
+        Some(path) => Ok(Some(path.to_string())),
+        None => Ok(None),
+    }
+}
+
+/**
+ * 指定されたディレクトリ内の画像をスキャンしてファイルパスのリストを返します
+ */
+#[tauri::command]
+pub async fn scan_directory(
+    path: String,
+) -> Result<Vec<ImageFileInfo>, String> {
+    // ディレクトリをスキャン
+    let image_paths = crate::fs_utils::scan_images_in_directory(&path)?;
+
+    // ファイル情報のリストを作成
+    let result: Vec<ImageFileInfo> = image_paths
+        .into_iter()
+        .map(|file_path| {
+            let file_name = crate::fs_utils::get_file_name(&file_path);
+            ImageFileInfo {
+                file_path,
+                file_name,
+            }
+        })
+        .collect();
+
+    println!("Scanned {} images", result.len());
+
+    Ok(result)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageFileInfo {
+    pub file_path: String,
+    pub file_name: String,
 }

--- a/image-gallery/src-tauri/src/db.rs
+++ b/image-gallery/src-tauri/src/db.rs
@@ -35,7 +35,8 @@ pub fn get_migrations() -> Vec<Migration> {
 }
 
 pub async fn init_db() -> Result<(), String> {
-    let db_path = get_db_path()?;
+    let _db_path = get_db_path()?;
     // データベースディレクトリが作成されたことを確認
     Ok(())
 }
+

--- a/image-gallery/src-tauri/src/fs_utils.rs
+++ b/image-gallery/src-tauri/src/fs_utils.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// 画像ファイルの拡張子リスト
+const VALID_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp"];
+
+/**
+ * 指定されたディレクトリ内の画像ファイルをスキャンします
+ *
+ * @param dir_path スキャンするディレクトリのパス
+ * @return 見つかった画像ファイルのパスの配列
+ */
+pub fn scan_images_in_directory(dir_path: &str) -> Result<Vec<String>, String> {
+    let mut image_paths = Vec::new();
+
+    for entry in WalkDir::new(dir_path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.file_type().is_file() {
+            if let Some(ext) = entry.path().extension() {
+                let ext_str = ext.to_str().unwrap_or("").to_lowercase();
+                if VALID_EXTENSIONS.contains(&ext_str.as_str()) {
+                    image_paths.push(entry.path().to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    Ok(image_paths)
+}
+
+/**
+ * パスからファイル名を取得します
+ *
+ * @param path ファイルのパス
+ * @return ファイル名
+ */
+pub fn get_file_name(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string()
+}

--- a/image-gallery/src-tauri/src/lib.rs
+++ b/image-gallery/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod db;
 mod commands;
+mod fs_utils;
 
 use commands::*;
 
@@ -18,6 +19,8 @@ pub fn run() {
         .add_migrations(&db_url, migrations)
         .build()
     )
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_fs::init())
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -31,6 +34,8 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       initialize_database,
       get_database_path,
+      select_directory,
+      scan_directory,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/image-gallery/src-tauri/tauri.conf.json
+++ b/image-gallery/src-tauri/tauri.conf.json
@@ -31,7 +31,12 @@
             "sql:allow-load",
             "sql:allow-execute",
             "sql:allow-close",
-            "sql:default"
+            "sql:default",
+            "dialog:allow-open",
+            "dialog:default",
+            "fs:allow-read-dir",
+            "fs:allow-read-file",
+            "fs:default"
           ]
         }
       ]

--- a/image-gallery/src/App.tsx
+++ b/image-gallery/src/App.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 import Database from '@tauri-apps/plugin-sql';
 import { useImageStore } from './store/imageStore';
 import { initializeDatabase, getDatabasePath } from './utils/tauri-commands';
+import Header from './components/Header';
 
 function App() {
-  const { error, setError, setLoading } = useImageStore();
+  const { images, currentDirectory, error, isLoading, setError, setLoading } = useImageStore();
 
   useEffect(() => {
     const init = async () => {
@@ -37,18 +38,40 @@ function App() {
   }, [setError, setLoading]);
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
-      <h1 className="text-3xl font-bold text-gray-900 mb-4">
-        Image Gallery Manager
-      </h1>
-      {error && (
-        <div className="bg-red-100 text-red-700 p-4 rounded">
-          Error: {error}
-        </div>
-      )}
-      <p className="text-gray-600">
-        Database initialized. Ready for next steps.
-      </p>
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+
+      <main className="p-4">
+        {error && (
+          <div className="bg-red-100 text-red-700 p-4 rounded mb-4">
+            Error: {error}
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="text-gray-600">Loading...</div>
+          </div>
+        )}
+
+        {!isLoading && currentDirectory && (
+          <div className="mb-4">
+            <p className="text-sm text-gray-600">
+              Current directory: <span className="font-medium">{currentDirectory}</span>
+            </p>
+            <p className="text-sm text-gray-600">
+              Images found: <span className="font-medium">{images.length}</span>
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !currentDirectory && (
+          <div className="flex flex-col items-center justify-center py-24 text-gray-500">
+            <p className="text-lg">No directory selected</p>
+            <p className="text-sm mt-2">Click "Select Directory" to get started</p>
+          </div>
+        )}
+      </main>
     </div>
   );
 }

--- a/image-gallery/src/components/Header.tsx
+++ b/image-gallery/src/components/Header.tsx
@@ -1,0 +1,51 @@
+import { FolderOpen } from 'lucide-react';
+import { useImageStore } from '../store/imageStore';
+import { selectDirectory, scanDirectory } from '../utils/tauri-commands';
+
+/**
+ * アプリケーションヘッダーコンポーネント
+ * ディレクトリ選択ボタンを表示します
+ */
+export default function Header() {
+  const { setImages, setCurrentDirectory, setLoading, setError } = useImageStore();
+
+  const handleSelectDirectory = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // ディレクトリ選択ダイアログを表示
+      const path = await selectDirectory();
+
+      if (path) {
+        console.log('Selected directory:', path);
+
+        // ディレクトリ内の画像をスキャン
+        const images = await scanDirectory(path);
+        console.log(`Scanned ${images.length} images`);
+
+        setImages(images);
+        setCurrentDirectory(path);
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(errorMessage);
+      console.error('Failed to select directory:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <header className="bg-white shadow-sm p-4 flex items-center justify-between">
+      <h1 className="text-2xl font-bold text-gray-900">Image Gallery</h1>
+      <button
+        onClick={handleSelectDirectory}
+        className="flex items-center gap-2 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors"
+      >
+        <FolderOpen size={20} />
+        Select Directory
+      </button>
+    </header>
+  );
+}

--- a/image-gallery/src/utils/tauri-commands.ts
+++ b/image-gallery/src/utils/tauri-commands.ts
@@ -1,5 +1,14 @@
 import { invoke } from '@tauri-apps/api/core';
+import Database from '@tauri-apps/plugin-sql';
 import type { ImageData, ImageMetadataUpdate } from '../types/image';
+
+/**
+ * ファイルシステムからスキャンされた画像ファイル情報
+ */
+interface ImageFileInfo {
+  file_path: string;
+  file_name: string;
+}
 
 /**
  * データベースを初期化します
@@ -19,37 +28,98 @@ export async function getDatabasePath(): Promise<string> {
   return await invoke<string>('get_database_path');
 }
 
+/**
+ * データベース接続を取得します
+ * @returns データベース接続
+ */
+async function getDatabase(): Promise<Database> {
+  const dbPath = await getDatabasePath();
+  const dbUrl = `sqlite:${dbPath}`;
+  return await Database.load(dbUrl);
+}
+
 // 後のステップで追加する関数のプレースホルダー
 
 /**
  * ディレクトリ選択ダイアログを表示します
  * @returns 選択されたディレクトリのパス、またはキャンセルされた場合はnull
- * @todo ステップ4で実装
  */
 export async function selectDirectory(): Promise<string | null> {
-  // TODO: ステップ4で実装
-  throw new Error('selectDirectory not yet implemented - will be added in Step 4');
+  return await invoke<string | null>('select_directory');
 }
 
 /**
  * 指定されたディレクトリ内の画像をスキャンしてデータベースに登録します
- * @param _path スキャンするディレクトリのパス
+ * @param path スキャンするディレクトリのパス
  * @returns スキャンされた画像データの配列
- * @todo ステップ4で実装
  */
-export async function scanDirectory(_path: string): Promise<ImageData[]> {
-  // TODO: ステップ4で実装
-  throw new Error('scanDirectory not yet implemented - will be added in Step 4');
+export async function scanDirectory(path: string): Promise<ImageData[]> {
+  // ファイルシステムから画像ファイルをスキャン
+  const fileInfos = await invoke<ImageFileInfo[]>('scan_directory', { path });
+
+  // データベースに接続
+  const db = await getDatabase();
+
+  try {
+    // データベースに画像を挿入
+    for (const fileInfo of fileInfos) {
+      // 既に存在するかチェック
+      const existing = await db.select<{ count: number }[]>(
+        'SELECT COUNT(*) as count FROM images WHERE file_path = $1',
+        [fileInfo.file_path]
+      );
+
+      if (existing[0].count === 0) {
+        // 存在しない場合は挿入
+        await db.execute(
+          'INSERT INTO images (file_path, file_name) VALUES ($1, $2)',
+          [fileInfo.file_path, fileInfo.file_name]
+        );
+      }
+    }
+
+    // すべての画像を取得して返す
+    return await getAllImages();
+  } finally {
+    await db.close();
+  }
 }
 
 /**
  * データベースからすべての画像を取得します
  * @returns すべての画像データの配列
- * @todo ステップ5で実装
  */
 export async function getAllImages(): Promise<ImageData[]> {
-  // TODO: ステップ5で実装
-  throw new Error('getAllImages not yet implemented - will be added in Step 5');
+  const db = await getDatabase();
+
+  try {
+    const results = await db.select<Array<{
+      id: number;
+      file_path: string;
+      file_name: string;
+      comment: string | null;
+      tags: string | null;
+      rating: number;
+      created_at: string;
+      updated_at: string;
+    }>>(
+      'SELECT id, file_path, file_name, comment, tags, rating, created_at, updated_at FROM images ORDER BY created_at DESC'
+    );
+
+    // tagsをJSON文字列から配列にパース
+    return results.map((row) => ({
+      id: row.id,
+      file_path: row.file_path,
+      file_name: row.file_name,
+      comment: row.comment,
+      tags: row.tags ? JSON.parse(row.tags) : [],
+      rating: row.rating,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    }));
+  } finally {
+    await db.close();
+  }
 }
 
 /**


### PR DESCRIPTION
## 概要

ステップ4の実装: ディレクトリ選択と画像スキャン機能

## 主な変更内容

### バックエンド (Rust)
- `tauri-plugin-dialog` と `tauri-plugin-fs` をインストールして設定
- `fs_utils.rs` モジュールを作成し、ディレクトリを再帰的にスキャンする機能を実装
- `select_directory` コマンドでフォルダ選択ダイアログを表示
- `scan_directory` コマンドでディレクトリ内の画像ファイル情報を返却
- サポート対象の画像形式: jpg, jpeg, png, gif, webp
- データベース操作をバックエンドから削除し、フロントエンドに移行

### フロントエンド (TypeScript/React)
- `Header` コンポーネントを新規作成し、ディレクトリ選択ボタンを実装
- `tauri-commands.ts` を更新し、`@tauri-apps/plugin-sql` を使用してフロントエンドから直接DB操作を実行
- `scanDirectory` 関数でファイルスキャンとDB挿入を実行
- `getAllImages` 関数でデータベースから全画像を取得
- `App.tsx` を更新し、現在のディレクトリと画像数を表示

### 設定
- `tauri.conf.json` に dialog と fs のパーミッションを追加

## アーキテクチャの変更

tauri-plugin-sql v2.x の設計に従い、データベース操作をフロントエンドで実行するように変更しました:
- Rust バックエンド: ファイルシステム操作のみを担当
- TypeScript フロントエンド: データベース操作を担当

この変更により、tauri-plugin-sql の推奨パターンに従った実装となっています。

## テスト計画

- [ ] ディレクトリ選択ダイアログが正常に表示されること
- [ ] 選択したディレクトリ内の画像ファイルがスキャンされること
- [ ] スキャンした画像がデータベースに正しく登録されること
- [ ] 既存の画像は重複して登録されないこと
- [ ] UIに現在のディレクトリと画像数が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)