### PR TITLE
Implement image detail modal (Step 6)

### DIFF
--- a/image-gallery/src/App.tsx
+++ b/image-gallery/src/App.tsx
@@ -4,6 +4,7 @@ import { useImageStore } from './store/imageStore';
 import { initializeDatabase, getDatabasePath } from './utils/tauri-commands';
 import Header from './components/Header';
 import ImageGrid from './components/ImageGrid';
+import ImageDetail from './components/ImageDetail';
 
 function App() {
   const { images, currentDirectory, error, isLoading, setError, setLoading } = useImageStore();
@@ -75,6 +76,9 @@ function App() {
 
         {!isLoading && currentDirectory && images.length > 0 && <ImageGrid />}
       </main>
+
+      {/* 画像詳細モーダル */}
+      <ImageDetail />
     </div>
   );
 }

--- a/image-gallery/src/components/ImageGrid.tsx
+++ b/image-gallery/src/components/ImageGrid.tsx
@@ -8,7 +8,7 @@ import { useImageStore } from '../store/imageStore';
  * 遅延読み込み（lazy loading）を使用してパフォーマンスを最適化します。
  */
 export default function ImageGrid() {
-  const { images } = useImageStore();
+  const { images, setSelectedImageId } = useImageStore();
 
   if (images.length === 0) {
     return (
@@ -29,12 +29,13 @@ export default function ImageGrid() {
           <div
             key={image.id}
             className="relative aspect-square overflow-hidden rounded-lg bg-gray-200 hover:shadow-lg transition-shadow cursor-pointer"
+            onClick={() => setSelectedImageId(image.id)}
           >
             <img
               src={imageUrl}
               alt={image.file_name}
               loading="lazy"
-              className="w-full h-full object-cover"
+              className="w-full h-full object-cover pointer-events-none"
               onError={(e) => {
                 // 画像読み込みエラー時の処理
                 const target = e.target as HTMLImageElement;
@@ -42,7 +43,7 @@ export default function ImageGrid() {
               }}
             />
             {/* 画像情報のオーバーレイ */}
-            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2">
+            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2 pointer-events-none">
               <p className="text-white text-xs truncate" title={image.file_name}>
                 {image.file_name}
               </p>

--- a/image-gallery/src/store/imageStore.ts
+++ b/image-gallery/src/store/imageStore.ts
@@ -9,6 +9,8 @@ interface ImageStore {
   images: ImageData[];
   /** 現在選択されているディレクトリのパス */
   currentDirectory: string | null;
+  /** 詳細表示で選択されている画像のID（未選択時はnull） */
+  selectedImageId: number | null;
   /** データ読み込み中かどうかを示すフラグ */
   isLoading: boolean;
   /** エラーメッセージ（エラーがない場合はnull） */
@@ -18,6 +20,8 @@ interface ImageStore {
   setImages: (images: ImageData[]) => void;
   /** 現在のディレクトリパスを設定します */
   setCurrentDirectory: (path: string | null) => void;
+  /** 選択された画像IDを設定します */
+  setSelectedImageId: (id: number | null) => void;
   /** ローディング状態を設定します */
   setLoading: (isLoading: boolean) => void;
   /** エラーメッセージを設定します */
@@ -36,11 +40,13 @@ interface ImageStore {
 export const useImageStore = create<ImageStore>((set) => ({
   images: [],
   currentDirectory: null,
+  selectedImageId: null,
   isLoading: false,
   error: null,
 
   setImages: (images) => set({ images }),
   setCurrentDirectory: (path) => set({ currentDirectory: path }),
+  setSelectedImageId: (id) => set({ selectedImageId: id }),
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),
   updateImage: (id, data) =>
@@ -50,5 +56,5 @@ export const useImageStore = create<ImageStore>((set) => ({
       ),
     })),
   clearError: () => set({ error: null }),
-  reset: () => set({ images: [], currentDirectory: null, isLoading: false, error: null }),
+  reset: () => set({ images: [], currentDirectory: null, selectedImageId: null, isLoading: false, error: null }),
 }));


### PR DESCRIPTION
## 概要

ステップ6の実装: 画像詳細表示モーダル機能

## 主な変更内容

### 新規コンポーネント

#### `ImageDetail.tsx`
- React Portalを使用して`<body>`直下にレンダリング
- フルサイズ画像とメタデータパネルを表示
- インラインスタイルで実装（Tailwind CSS適用問題を回避）

### 主な機能

1. **画像詳細モーダル表示**
   - 画像をクリックして詳細モーダルを開く
   - 黒い半透明背景で表示
   - 中央に画像、右側にメタデータパネル

2. **メタデータ表示**
   - ファイル名
   - レーティング（星5段階）
   - タグ（もしあれば）
   - コメント（もしあれば）
   - ファイルパス
   - 作成日時・更新日時
   - 画像の位置（例: 17 / 171）

3. **画像ナビゲーション**
   - 前の画像/次の画像ボタン
   - 左矢印キー/右矢印キーでナビゲーション
   - 最初/最後の画像では該当ボタンを非表示

4. **モーダルを閉じる方法**
   - ×ボタンをクリック
   - ESCキーを押す
   - 背景をクリック

5. **技術的な工夫**
   - React Portalで親要素の制約を回避
   - インラインスタイルでTailwind CSS適用問題を解決
   - `pointer-events-none`でクリックイベントの伝播を制御

### 状態管理の更新

- `imageStore.ts`に`selectedImageId`状態を追加
- `setSelectedImageId`関数でモーダルの開閉を制御

### UIコンポーネントの更新

- `ImageGrid.tsx`にクリックハンドラーを追加
- `App.tsx`にImageDetailコンポーネントを統合

## テスト結果

✅ 画像をクリックしてモーダルが開く
✅ フルサイズ画像が表示される
✅ メタデータが正しく表示される
✅ 前の画像/次の画像ボタンで移動できる
✅ 左右矢印キーで移動できる
✅ ESCキーでモーダルが閉じる
✅ ×ボタンでモーダルが閉じる
✅ 背景クリックでモーダルが閉じる

## 動作確認済み

171枚の画像で動作確認済み。すべての機能が正常に動作しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)