### PR TITLE
[Step 2] ファイルスキャン機能の拡張（MP4対応）

### DIFF
--- a/image-gallery/src-tauri/src/commands.rs
+++ b/image-gallery/src-tauri/src/commands.rs
@@ -31,28 +31,30 @@ pub async fn select_directory(app: tauri::AppHandle) -> Result<Option<String>, S
 }
 
 /**
- * 指定されたディレクトリ内の画像をスキャンしてファイルパスのリストを返します
+ * 指定されたディレクトリ内の画像・動画をスキャンしてファイルパスのリストを返します
  */
 #[tauri::command]
 pub async fn scan_directory(
     path: String,
 ) -> Result<Vec<ImageFileInfo>, String> {
     // ディレクトリをスキャン
-    let image_paths = crate::fs_utils::scan_images_in_directory(&path)?;
+    let file_paths = crate::fs_utils::scan_images_in_directory(&path)?;
 
     // ファイル情報のリストを作成
-    let result: Vec<ImageFileInfo> = image_paths
+    let result: Vec<ImageFileInfo> = file_paths
         .into_iter()
         .map(|file_path| {
             let file_name = crate::fs_utils::get_file_name(&file_path);
+            let file_type = crate::fs_utils::get_file_type(&file_path);
             ImageFileInfo {
                 file_path,
                 file_name,
+                file_type,
             }
         })
         .collect();
 
-    println!("Scanned {} images", result.len());
+    println!("Scanned {} files (images and videos)", result.len());
 
     Ok(result)
 }
@@ -61,4 +63,5 @@ pub async fn scan_directory(
 pub struct ImageFileInfo {
     pub file_path: String,
     pub file_name: String,
+    pub file_type: String,
 }

--- a/image-gallery/src-tauri/src/fs_utils.rs
+++ b/image-gallery/src-tauri/src/fs_utils.rs
@@ -2,16 +2,46 @@ use std::path::Path;
 use walkdir::WalkDir;
 
 /// 画像ファイルの拡張子リスト
-const VALID_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp"];
+const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp"];
+
+/// 動画ファイルの拡張子リスト
+const VIDEO_EXTENSIONS: &[&str] = &["mp4"];
+
+/// すべてのサポート対象拡張子を取得
+fn get_all_extensions() -> Vec<&'static str> {
+    let mut exts = Vec::new();
+    exts.extend_from_slice(IMAGE_EXTENSIONS);
+    exts.extend_from_slice(VIDEO_EXTENSIONS);
+    exts
+}
 
 /**
- * 指定されたディレクトリ内の画像ファイルをスキャンします
+ * ファイルの種類を判定します
+ *
+ * @param path ファイルのパス
+ * @return "image", "video", または "unknown"
+ */
+pub fn get_file_type(path: &str) -> String {
+    if let Some(ext) = Path::new(path).extension() {
+        let ext_str = ext.to_str().unwrap_or("").to_lowercase();
+        if IMAGE_EXTENSIONS.contains(&ext_str.as_str()) {
+            return "image".to_string();
+        } else if VIDEO_EXTENSIONS.contains(&ext_str.as_str()) {
+            return "video".to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+/**
+ * 指定されたディレクトリ内のメディアファイル（画像・動画）をスキャンします
  *
  * @param dir_path スキャンするディレクトリのパス
- * @return 見つかった画像ファイルのパスの配列
+ * @return 見つかったメディアファイルのパスの配列
  */
 pub fn scan_images_in_directory(dir_path: &str) -> Result<Vec<String>, String> {
-    let mut image_paths = Vec::new();
+    let valid_extensions = get_all_extensions();
+    let mut file_paths = Vec::new();
 
     for entry in WalkDir::new(dir_path)
         .into_iter()
@@ -20,14 +50,14 @@ pub fn scan_images_in_directory(dir_path: &str) -> Result<Vec<String>, String> {
         if entry.file_type().is_file() {
             if let Some(ext) = entry.path().extension() {
                 let ext_str = ext.to_str().unwrap_or("").to_lowercase();
-                if VALID_EXTENSIONS.contains(&ext_str.as_str()) {
-                    image_paths.push(entry.path().to_string_lossy().to_string());
+                if valid_extensions.contains(&ext_str.as_str()) {
+                    file_paths.push(entry.path().to_string_lossy().to_string());
                 }
             }
         }
     }
 
-    Ok(image_paths)
+    Ok(file_paths)
 }
 
 /**


### PR DESCRIPTION
## 概要
MP4ファイルもスキャン対象に含め、ファイル種別を判定してデータベースに登録できるようにしました。

Closes #10
Related to #8 (MP4動画対応の実装)
Depends on #15 (ステップ1: マージ済み)

## 実装内容

### 1. ファイル拡張子リストの更新 (src-tauri/src/fs_utils.rs)
- `VALID_EXTENSIONS` を `IMAGE_EXTENSIONS` と `VIDEO_EXTENSIONS` に分離
- `VIDEO_EXTENSIONS` に "mp4" を追加
- `get_all_extensions()` 関数を実装して全拡張子を統合
- `get_file_type()` 関数を実装してファイル種別を判定
  - 画像拡張子 → "image"
  - 動画拡張子 → "video"
  - その他 → "unknown"

### 2. スキャン機能の更新 (src-tauri/src/fs_utils.rs)
- `scan_images_in_directory()` を更新してMP4も検出
- 関数ドキュメントを「画像」から「メディアファイル（画像・動画）」に更新

### 3. コマンド更新 (src-tauri/src/commands.rs)
- `ImageFileInfo` 構造体に `file_type` フィールドを追加
- `scan_directory` コマンドで `get_file_type()` を呼び出し
- フロントエンドにファイル種別を返却
- ログメッセージを「images」から「files (images and videos)」に更新

### 4. フロントエンドの更新 (src/utils/tauri-commands.ts)
- `ImageFileInfo` インターフェースに `file_type` を追加
- `scanDirectory()` でバックエンドから取得した `file_type` を使用
- ステップ1で仮置きしていた 'image' の固定値を削除
- JSDocコメントを更新

## 変更ファイル
- ✅ `src-tauri/src/fs_utils.rs` - MP4拡張子追加、get_file_type()実装
- ✅ `src-tauri/src/commands.rs` - file_type対応
- ✅ `src/utils/tauri-commands.ts` - file_type使用

## 確認項目
- [x] MP4ファイルを含むディレクトリを選択できる
- [x] スキャン後、MP4ファイルがデータベースに登録される
- [x] データベースの `file_type` カラムに 'video' が保存される
- [x] 既存の画像ファイルも引き続き動作する
- [x] TypeScriptのコンパイルエラーがない
- [x] Rustのコンパイルエラーがない

## テスト結果
- TypeScript compilation: ✅ Passed
- Rust compilation: ✅ Passed
- Build: ✅ Success

## 動作確認方法
1. アプリを起動
2. 画像とMP4ファイルが混在するディレクトリを選択
3. データベースを確認して `file_type` が正しく設定されていることを確認
   - 画像ファイル: `file_type = 'image'`
   - MP4ファイル: `file_type = 'video'`

## 次のステップ
ステップ3（#11）で、グリッド表示での動画対応を実装します。動画サムネイルと再生アイコンを表示します。

## スクリーンショット
N/A（バックエンド機能の実装のみ）