### PR TITLE
Implement slideshow functionality (Step 10)

### DIFF
--- a/image-gallery/src/components/SlideshowControls.tsx
+++ b/image-gallery/src/components/SlideshowControls.tsx
@@ -1,0 +1,146 @@
+import { Play, Pause, SkipForward, SkipBack } from 'lucide-react';
+import { useImageStore } from '../store/imageStore';
+import type { SlideshowInterval } from '../store/imageStore';
+
+interface SlideshowControlsProps {
+  currentIndex: number;
+  totalCount: number;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+/**
+ * スライドショーコントロールパネルコンポーネント
+ * 再生/一時停止、スキップ、速度調整を提供します
+ */
+export default function SlideshowControls({
+  currentIndex,
+  totalCount,
+  onPrevious,
+  onNext,
+}: SlideshowControlsProps) {
+  const { isSlideshowActive, slideshowInterval, toggleSlideshow, setSlideshowInterval } =
+    useImageStore();
+
+  const intervals: SlideshowInterval[] = [3, 5, 10];
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: '20px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 10,
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        borderRadius: '8px',
+        padding: '12px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '16px',
+        color: 'white',
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Previous button */}
+      <button
+        onClick={onPrevious}
+        disabled={currentIndex === 0}
+        style={{
+          padding: '8px',
+          backgroundColor: 'transparent',
+          border: 'none',
+          color: 'white',
+          cursor: currentIndex === 0 ? 'not-allowed' : 'pointer',
+          opacity: currentIndex === 0 ? 0.5 : 1,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        aria-label="Previous"
+      >
+        <SkipBack size={20} />
+      </button>
+
+      {/* Play/Pause button */}
+      <button
+        onClick={toggleSlideshow}
+        style={{
+          padding: '8px',
+          backgroundColor: '#3b82f6',
+          border: 'none',
+          borderRadius: '4px',
+          color: 'white',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        aria-label={isSlideshowActive ? 'Pause' : 'Play'}
+      >
+        {isSlideshowActive ? <Pause size={20} /> : <Play size={20} />}
+      </button>
+
+      {/* Next button */}
+      <button
+        onClick={onNext}
+        disabled={currentIndex === totalCount - 1}
+        style={{
+          padding: '8px',
+          backgroundColor: 'transparent',
+          border: 'none',
+          color: 'white',
+          cursor: currentIndex === totalCount - 1 ? 'not-allowed' : 'pointer',
+          opacity: currentIndex === totalCount - 1 ? 0.5 : 1,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        aria-label="Next"
+      >
+        <SkipForward size={20} />
+      </button>
+
+      {/* Divider */}
+      <div
+        style={{
+          width: '1px',
+          height: '24px',
+          backgroundColor: 'rgba(255, 255, 255, 0.3)',
+        }}
+      />
+
+      {/* Speed selector */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <span style={{ fontSize: '14px', color: '#d1d5db' }}>Speed:</span>
+        <div style={{ display: 'flex', gap: '4px' }}>
+          {intervals.map((interval) => (
+            <button
+              key={interval}
+              onClick={() => setSlideshowInterval(interval)}
+              style={{
+                padding: '4px 8px',
+                backgroundColor:
+                  slideshowInterval === interval ? '#3b82f6' : 'rgba(255, 255, 255, 0.1)',
+                border: 'none',
+                borderRadius: '4px',
+                color: 'white',
+                cursor: 'pointer',
+                fontSize: '14px',
+              }}
+            >
+              {interval}s
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Progress */}
+      <div
+        style={{
+          fontSize: '14px',
+          color: '#d1d5db',
+        }}
+      >
+        {currentIndex + 1} / {totalCount}
+      </div>
+    </div>
+  );
+}

--- a/image-gallery/src/store/imageStore.ts
+++ b/image-gallery/src/store/imageStore.ts
@@ -34,6 +34,11 @@ export interface FilterSettings {
 }
 
 /**
+ * スライドショーの再生間隔（秒）
+ */
+export type SlideshowInterval = 3 | 5 | 10;
+
+/**
  * 画像ギャラリーのグローバル状態を管理するストアのインターフェース
  */
 interface ImageStore {
@@ -55,6 +60,10 @@ interface ImageStore {
   filterSettings: FilterSettings;
   /** 検索クエリ */
   searchQuery: string;
+  /** スライドショーが有効かどうか */
+  isSlideshowActive: boolean;
+  /** スライドショーの再生間隔（秒） */
+  slideshowInterval: SlideshowInterval;
 
   /** 画像データの配列を設定します */
   setImages: (images: ImageData[]) => void;
@@ -92,6 +101,14 @@ interface ImageStore {
   getSortedAndFilteredImages: () => ImageData[];
   /** ソート済みの画像配列を取得します（後方互換性のため残す） */
   getSortedImages: () => ImageData[];
+  /** スライドショーを開始します */
+  startSlideshow: () => void;
+  /** スライドショーを停止します */
+  stopSlideshow: () => void;
+  /** スライドショーの再生/一時停止を切り替えます */
+  toggleSlideshow: () => void;
+  /** スライドショーの再生間隔を設定します */
+  setSlideshowInterval: (interval: SlideshowInterval) => void;
 }
 
 /**
@@ -117,6 +134,8 @@ export const useImageStore = create<ImageStore>()(
       sortOrder: 'desc',
       filterSettings: defaultFilterSettings,
       searchQuery: '',
+      isSlideshowActive: false,
+      slideshowInterval: 5,
 
       setImages: (images) => set({ images }),
       setCurrentDirectory: (path) => set({ currentDirectory: path }),
@@ -242,6 +261,10 @@ export const useImageStore = create<ImageStore>()(
         // 後方互換性のため、getSortedAndFilteredImagesを呼び出す
         return get().getSortedAndFilteredImages();
       },
+      startSlideshow: () => set({ isSlideshowActive: true }),
+      stopSlideshow: () => set({ isSlideshowActive: false }),
+      toggleSlideshow: () => set((state) => ({ isSlideshowActive: !state.isSlideshowActive })),
+      setSlideshowInterval: (interval) => set({ slideshowInterval: interval }),
     }),
     {
       name: 'image-gallery-settings',
@@ -249,6 +272,7 @@ export const useImageStore = create<ImageStore>()(
         sortBy: state.sortBy,
         sortOrder: state.sortOrder,
         filterSettings: state.filterSettings,
+        slideshowInterval: state.slideshowInterval,
       }),
     }
   )


### PR DESCRIPTION
## Summary
This PR implements a comprehensive slideshow feature with auto-play, manual controls, and configurable playback speed, addressing Issue #31.

Users can now:
- Start a slideshow from the image detail view
- Auto-advance through images at configurable intervals (3s, 5s, or 10s)
- Play/pause the slideshow
- Skip forward/backward manually
- Adjust playback speed on-the-fly
- View clean, distraction-free images during slideshow mode

## Implementation Details

### State Management (imageStore)
Added slideshow-related state and actions:
- **isSlideshowActive** (boolean): Tracks whether slideshow is currently playing
- **slideshowInterval** (3 | 5 | 10): Configurable playback interval in seconds
- **startSlideshow()**: Activates slideshow mode
- **stopSlideshow()**: Deactivates slideshow mode
- **toggleSlideshow()**: Toggles between play/pause
- **setSlideshowInterval(interval)**: Changes playback speed
- Slideshow interval persists in localStorage

### SlideshowControls Component
Created a new control panel component with:
- **Play/Pause button**: Blue highlight, toggles slideshow state
- **Previous/Next skip buttons**: Navigate manually, disabled at boundaries
- **Speed selector**: Three buttons for 3s/5s/10s intervals
- **Progress indicator**: Shows "current / total" position
- **Design**: Semi-transparent black background, centered at bottom
- All controls stop event propagation to prevent modal closure

### ImageDetail Component Updates

#### Slideshow Start Button
- Added Presentation icon button next to close button
- Only visible when slideshow is inactive and not editing
- Starts slideshow when clicked

#### Auto-Advance Logic
- New useEffect hook monitors slideshow state
- Uses setTimeout with slideshowInterval * 1000ms
- Automatically advances to next image when active
- Stops slideshow when reaching last image
- Cleans up timer on component unmount or state change

#### UI Adaptations
- **During slideshow**:
  - Hides metadata panel for clean viewing
  - Hides standard prev/next chevron buttons
  - Shows SlideshowControls panel
  - Disables keyboard shortcuts (except ESC)
- **Stop conditions**:
  - ESC key press
  - Close button click
  - Reaching last image
  - User manually closing modal

#### Navigation Handlers
- Created `handlePrevious()` and `handleNext()` helper functions
- Shared by both SlideshowControls and keyboard shortcuts
- Properly handle boundary conditions

### User Experience Flow

1. **Starting slideshow**:
   - User views image in detail mode
   - Clicks Presentation icon button
   - Slideshow mode activates

2. **During slideshow**:
   - Image changes automatically at set interval
   - Control panel appears at bottom
   - Metadata panel hidden
   - Standard navigation hidden

3. **Controlling playback**:
   - Click play/pause to toggle auto-advance
   - Click skip buttons for manual navigation
   - Click speed buttons to change interval
   - Progress indicator shows position

4. **Stopping slideshow**:
   - Press ESC key
   - Click close button
   - Reach last image (auto-stops)
   - All return to normal detail view

## Technical Highlights

- **State persistence**: Slideshow interval preference saved to localStorage
- **Clean separation**: SlideshowControls is a reusable component
- **Proper cleanup**: useEffect cleanup prevents timer leaks
- **Boundary handling**: Skip buttons and auto-advance respect image boundaries
- **Event handling**: stopPropagation prevents accidental modal closure
- **Accessibility**: Proper ARIA labels and disabled states

## Test Plan
- [x] Build passes successfully
- [ ] Presentation button appears in image detail view
- [ ] Clicking Presentation button starts slideshow
- [ ] Images auto-advance at selected interval
- [ ] Play/pause button toggles auto-advance
- [ ] Skip buttons navigate correctly
- [ ] Skip buttons disabled at boundaries
- [ ] Speed selector changes interval
- [ ] Interval preference persists after reload
- [ ] Slideshow stops at last image
- [ ] ESC key stops slideshow
- [ ] Close button stops slideshow
- [ ] Metadata panel hidden during slideshow
- [ ] Progress indicator shows correct position
- [ ] Standard navigation hidden during slideshow

## Related Issues
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)