### PR TITLE
プロジェクト構成図のdoc/ファイルパス404エラーを修正

### DIFF
--- a/image-gallery/README.md
+++ b/image-gallery/README.md
@@ -85,12 +85,12 @@ npm run tauri:build
 ## プロジェクト構成
 
 ```
-image-gallery/
-├── doc/                           # ドキュメント
-│   ├── 01_requirement.md          # 要件定義
-│   ├── 02_mp4-support-plan.md     # Phase 1 実装プラン
-│   └── 03_phase2-proposal.md      # Phase 2 開発提案
-└── image-gallery/
+image-gallery/                     # リポジトリルート
+├── doc/                           # ドキュメント（プロジェクト計画・要件定義）
+│   ├── 01_requirement             # 要件定義
+│   ├── 02_mp4-support-plan        # Phase 1 実装プラン
+│   └── 03_phase2-proposal         # Phase 2 開発提案
+└── image-gallery/                 # アプリケーション本体
     ├── src/                       # React フロントエンドコード
     │   ├── components/            # UIコンポーネント
     │   │   ├── Header.tsx         # ヘッダー（ディレクトリ選択、統計表示）


### PR DESCRIPTION
## 概要

README.md のプロジェクト構成図で、doc/ 配下のファイルが GitHub 上で自動的にリンクになり、404エラーになる問題を修正しました。

## 問題の詳細

- README.md は `image-gallery/README.md` に配置されている
- doc/ ディレクトリはリポジトリルート（`../doc/`）に配置されている
- GitHub が `.md` 拡張子を持つファイル名を自動的にリンクにしようとする
- 相対パスで解決されるため `image-gallery/doc/01_requirement.md` → 404エラー

## 修正内容

### doc/ 配下のファイル名から .md 拡張子を削除

```diff
-│   ├── 01_requirement.md          # 要件定義
-│   ├── 02_mp4-support-plan.md     # Phase 1 実装プラン
-│   └── 03_phase2-proposal.md      # Phase 2 開発提案
+│   ├── 01_requirement             # 要件定義
+│   ├── 02_mp4-support-plan        # Phase 1 実装プラン
+│   └── 03_phase2-proposal         # Phase 2 開発提案
```

### プロジェクト構成図のコメントを明確化

- リポジトリルート構造であることを明示
- doc/ ディレクトリの説明をより詳しく記載
- image-gallery/ ディレクトリが「アプリケーション本体」であることを明記

## テスト

- [x] GitHub 上でプロジェクト構成図を確認し、404リンクがないことを確認
- [x] 構造の説明が明確であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)