### PR TITLE
README.md内のすべての.md自動リンク404エラーを修正

### DIFF
--- a/image-gallery/README.md
+++ b/image-gallery/README.md
@@ -118,8 +118,8 @@ image-gallery/                     # リポジトリルート
     │   │   ├── db.rs              # データベース管理
     │   │   └── fs_utils.rs        # ファイルシステムユーティリティ
     │   └── tauri.conf.json        # Tauri設定
-    ├── CLAUDE.md                  # Claude Code 開発ガイド
-    └── README.md                  # このファイル
+    ├── CLAUDE                     # Claude Code 開発ガイド
+    └── README                     # このファイル
 ```
 
 ## 使い方
@@ -294,7 +294,7 @@ rm ~/Library/Application\ Support/com.imagegallery/gallery.db
 
 このプロジェクトはClaude Codeでの開発に最適化されています。開発を始める前に **[CLAUDE.md](./CLAUDE.md)** を必ずお読みください。
 
-**CLAUDE.mdの内容:**
+**CLAUDEガイドの内容:**
 - プロジェクト構造の詳細説明
 - Tailwind CSS v4の重要な注意点
 - ダークモード対応のガイドライン


### PR DESCRIPTION
## 概要

前回の修正（#58）では doc/ 配下のファイルのみ対応しましたが、プロジェクト構成図内の `CLAUDE.md` と `README.md` もGitHub上で自動的にリンクになり、404エラーになっていました。今回はこれらすべてを修正しました。

## 問題の詳細

GitHub がコードブロック内の `.md` 拡張子を持つファイル名を自動的にリンクにしようとします：

### 404になっていた箇所

1. **プロジェクト構成図 line 121**: `├── CLAUDE.md`
2. **プロジェクト構成図 line 122**: `└── README.md`
3. **見出し line 297**: `**CLAUDE.mdの内容:**`

これらすべてがGitHub上で相対パスリンクとなり、404エラーになっていました。

## 修正内容

### 1. プロジェクト構成図内のファイル名から.md拡張子を削除

```diff
-    ├── CLAUDE.md                  # Claude Code 開発ガイド
-    └── README.md                  # このファイル
+    ├── CLAUDE                     # Claude Code 開発ガイド
+    └── README                     # このファイル
```

### 2. 見出しテキストの修正

```diff
-**CLAUDE.mdの内容:**
+**CLAUDEガイドの内容:**
```

## 確認事項

- ✅ プロジェクト構成図で404リンクがないことを確認
- ✅ 実際のmarkdownリンク `[CLAUDE.md](./CLAUDE.md)` は残して正常に機能することを確認
- ✅ 構造の説明が依然として明確であることを確認

## 補足

以下の正規のmarkdownリンクは**そのまま残しています**（これらは正常に動作します）：

- `[CLAUDE.md](./CLAUDE.md)` - 実際のファイルへの相対パスリンク（line 41, 226, 295, 340, 351）

🤖 Generated with [Claude Code](https://claude.com/claude-code)