### PR TITLE
CLAUDE.md内のdoc/へのリンク404エラーを修正

### DIFF
--- a/image-gallery/CLAUDE.md
+++ b/image-gallery/CLAUDE.md
@@ -344,9 +344,9 @@ rm ~/Library/Application\ Support/com.imagegallery/gallery.db
 
 ### プロジェクト内ドキュメント
 - [README.md](./README.md) - プロジェクト概要
-- [doc/01_requirement.md](./doc/01_requirement.md) - 要件定義
-- [doc/02_mp4-support-plan.md](./doc/02_mp4-support-plan.md) - Phase 1プラン
-- [doc/03_phase2-proposal.md](./doc/03_phase2-proposal.md) - Phase 2提案
+- [doc/01_requirement.md](../doc/01_requirement.md) - 要件定義
+- [doc/02_mp4-support-plan.md](../doc/02_mp4-support-plan.md) - Phase 1プラン
+- [doc/03_phase2-proposal.md](../doc/03_phase2-proposal.md) - Phase 2提案
 
 ## Claude Codeとの協働のコツ
 


### PR DESCRIPTION
## 概要

CLAUDE.md の「プロジェクト内ドキュメント」セクションで、doc/ へのリンクが404エラーになっていた問題を修正しました。

## 問題の詳細

CLAUDE.mdは `image-gallery/CLAUDE.md` に配置されていますが、doc/ ディレクトリはリポジトリルート（親ディレクトリ）に配置されています：

```
image-gallery/              # リポジトリルート
├── doc/                    # ドキュメントディレクトリ
│   ├── 01_requirement.md
│   ├── 02_mp4-support-plan.md
│   └── 03_phase2-proposal.md
└── image-gallery/          # アプリケーション本体
    └── CLAUDE.md           # このファイル
```

CLAUDE.md内のリンクが `./doc/01_requirement.md` のように記述されていたため、`image-gallery/doc/01_requirement.md` を参照しようとして404エラーになっていました。

## 修正内容

相対パスを `./doc/` から `../doc/` に修正しました：

```diff
 ### プロジェクト内ドキュメント
 - [README.md](./README.md) - プロジェクト概要
-- [doc/01_requirement.md](./doc/01_requirement.md) - 要件定義
-- [doc/02_mp4-support-plan.md](./doc/02_mp4-support-plan.md) - Phase 1プラン
-- [doc/03_phase2-proposal.md](./doc/03_phase2-proposal.md) - Phase 2提案
+- [doc/01_requirement.md](../doc/01_requirement.md) - 要件定義
+- [doc/02_mp4-support-plan.md](../doc/02_mp4-support-plan.md) - Phase 1プラン
+- [doc/03_phase2-proposal.md](../doc/03_phase2-proposal.md) - Phase 2提案
```

## 修正後のパス解決

- CLAUDE.md: `image-gallery/CLAUDE.md`
- リンク: `../doc/01_requirement.md`
- 解決先: `doc/01_requirement.md` ✅

## 確認事項

- ✅ 3つすべてのdoc/リンクのパスを修正
- ✅ 実際のファイル名と一致することを確認
- ✅ 相対パスが正しく解決されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)