### PR TITLE
リポジトリルートREADME.mdのドキュメントリンク404エラーを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd image-gallery
 npm install
 ```
 
-## 開発
+  ## 開発
 
 ```bash
 npm run tauri:dev
@@ -44,8 +44,9 @@ npm run tauri:build
 
 ## ドキュメント
 
-- [要件定義](./doc/requiment.md)
-- [実装プラン](./doc/implementation-plan.md)
+- [要件定義](./doc/01_requirement.md)
+- [Phase 1 実装プラン (MP4対応)](./doc/02_mp4-support-plan.md)
+- [Phase 2 開発提案](./doc/03_phase2-proposal.md)
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要

リポジトリルート `README.md` の「ドキュメント」セクション（45-48行目）で、リンク先のファイル名が間違っていて404エラーになっていた問題を修正しました。

## 問題の詳細

ドキュメントセクションのリンクが実際のファイル名と一致していませんでした：

### 間違っていたリンク

1. **`./doc/requiment.md`** 
   - ❌ typo: "requiment" → 正しくは "requirement"
   - ❌ 実際のファイル名は `01_requirement.md`

2. **`./doc/implementation-plan.md`**
   - ❌ このファイル名は存在しない
   - ✅ 実際には `02_mp4-support-plan.md` と `03_phase2-proposal.md`

### 実際のdoc/ディレクトリ構成

```
doc/
├── 01_requirement.md
├── 02_mp4-support-plan.md
└── 03_phase2-proposal.md
```

## 修正内容

ドキュメントセクションのリンクを実際のファイル名に修正しました：

```diff
 ## ドキュメント
 
-- [要件定義](./doc/requiment.md)
-- [実装プラン](./doc/implementation-plan.md)
+- [要件定義](./doc/01_requirement.md)
+- [Phase 1 実装プラン (MP4対応)](./doc/02_mp4-support-plan.md)
+- [Phase 2 開発提案](./doc/03_phase2-proposal.md)
```

## 修正後の動作

- ✅ 要件定義へのリンクが正しく動作
- ✅ Phase 1実装プランへのリンクが正しく動作
- ✅ Phase 2開発提案へのリンクが正しく動作（新規追加）

## 確認事項

- ✅ 3つすべてのドキュメントファイルが実際に存在することを確認
- ✅ リンクのパスが正しいことを確認
- ✅ リンクテキストが内容を適切に説明していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)