### PR TITLE
Phase 4 Step 6: グループフィルター統合

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   getAllGroups,
   updateGroup,
   deleteGroup,
+  getGroupImages,
 } from '../utils/tauri-commands';
 import GroupItem from './GroupItem';
 import GroupModal from './GroupModal';
@@ -29,6 +30,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
     removeGroup,
     selectedGroupId,
     setSelectedGroupId,
+    setGroupFilteredImageIds,
   } = useImageStore();
 
   const [showModal, setShowModal] = useState(false);
@@ -88,6 +90,23 @@ export default function Sidebar({ isOpen }: SidebarProps) {
     setEditingGroup(null);
   };
 
+  const handleSelectAllImages = () => {
+    setSelectedGroupId(null);
+    setGroupFilteredImageIds([]);
+  };
+
+  const handleSelectGroup = async (groupId: number) => {
+    try {
+      setSelectedGroupId(groupId);
+      const imageIds = await getGroupImages(groupId);
+      setGroupFilteredImageIds(imageIds);
+    } catch (err) {
+      console.error('Failed to get group images:', err);
+      setSelectedGroupId(null);
+      setGroupFilteredImageIds([]);
+    }
+  };
+
   if (!isOpen) {
     return null;
   }
@@ -111,7 +130,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
 
           {/* All Images ボタン */}
           <button
-            onClick={() => setSelectedGroupId(null)}
+            onClick={handleSelectAllImages}
             className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
               selectedGroupId === null
                 ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200'
@@ -137,7 +156,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
                   key={group.id}
                   group={group}
                   isSelected={selectedGroupId === group.id}
-                  onClick={() => setSelectedGroupId(group.id)}
+                  onClick={() => handleSelectGroup(group.id)}
                   onEdit={() => handleEditGroup(group)}
                   onDelete={() => handleDeleteGroup(group.id)}
                 />


### PR DESCRIPTION
## 概要

Phase 4（画像グループ化機能）のStep 6を実装しました。
グループフィルター機能と画像詳細への所属グループ表示を追加しています。

## 実装内容

### 変更ファイル

#### 1. `imageStore.ts` - グループフィルターステート追加
- **新規ステート**: `groupFilteredImageIds: number[]`
  - グループフィルター用の画像IDリスト
  - `selectedGroupId`がnullでない場合のみ使用
- **新規アクション**: `setGroupFilteredImageIds(ids: number[])`
  - グループ選択時に画像IDリストを保存
- **`getSortedAndFilteredImages`の拡張**
  - グループフィルターロジックを追加（最優先）
  - `selectedGroupId`がnullでない場合、`groupFilteredImageIds`に含まれる画像のみ表示
  - 既存のフィルター（検索、お気に入り、ファイルタイプ、評価、タグ）と連携

#### 2. `Sidebar.tsx` - グループ選択処理の実装
- **`getGroupImages`のインポート**
- **`handleSelectAllImages`関数**
  - 「All Images」ボタンクリック時
  - `selectedGroupId`をnullに設定
  - `groupFilteredImageIds`を空配列に設定
- **`handleSelectGroup`関数**（非同期）
  - グループ選択時に`getGroupImages(groupId)`を呼び出し
  - 取得した画像IDリストを`setGroupFilteredImageIds`で保存
  - エラー時は選択をクリア

#### 3. `ImageDetail.tsx` - 所属グループ表示
- **`getImageGroups`、`Folder`アイコンのインポート**
- **`belongingGroupIds`ステート追加**
  - 現在表示中の画像が所属するグループIDのリスト
- **useEffectで所属グループを取得**
  - 画像変更時に`getImageGroups(selectedImage.id)`を呼び出し
  - 取得したグループIDを`belongingGroupIds`に保存
- **所属グループ表示セクション**（コメントセクションの後に追加）
  - カラーインジケーター（丸いドット）
  - Folderアイコン
  - グループ名
  - 未所属時: 「Not in any group」メッセージ

## 技術的特徴

- ✅ **自動フィルタリング**: グループ選択時に自動的に画像IDを取得してフィルター適用
- ✅ **既存フィルターとの連携**: グループフィルターと検索・タグ・評価フィルターが同時に動作
- ✅ **非同期処理**: グループ画像取得をコンポーネント側で処理（ストアは同期関数を維持）
- ✅ **エラーハンドリング**: 画像ID取得失敗時は自動的にフィルターをクリア
- ✅ **ダークモード対応**: すべての新規UI要素でダーク/ライトモード対応

## ユーザーフロー

1. サイドバーでグループを選択
2. 自動的にそのグループに所属する画像のみ表示される
3. 既存のフィルター（検索、タグなど）も併用可能
4. 画像詳細モーダルで所属グループを確認できる
5. 「All Images」で全画像表示に戻る

## テスト項目

### 手動テスト
- [ ] グループ選択で画像が正しくフィルタリングされる
- [ ] 「All Images」で全画像が表示される
- [ ] グループフィルターと検索フィルターの併用
- [ ] グループフィルターとタグフィルターの併用
- [ ] 画像詳細に所属グループが表示される
- [ ] 未所属の画像は「Not in any group」と表示される
- [ ] 複数グループに所属する画像の表示
- [ ] ダークモードでの表示確認

### ビルド確認
- [x] `npm run build` 成功
- [x] TypeScriptコンパイルエラーなし

## 次のステップ

Step 7では、統合テストと調整を行います：
- パフォーマンステスト（大量画像/グループ）
- エッジケーステスト
- キーボードショートカットの統合確認
- レスポンシブ対応の最終確認
- バグ修正と仕上げ

## 関連Issue

Closes #72

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>