### PR TITLE
fix: グループ二重作成バグを修正 #81

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,7 +25,6 @@ export default function Sidebar({ isOpen }: SidebarProps) {
   const {
     groups,
     setGroups,
-    addGroup,
     updateGroup: updateGroupInStore,
     removeGroup,
     selectedGroupId,
@@ -47,15 +46,9 @@ export default function Sidebar({ isOpen }: SidebarProps) {
       updateGroupInStore(input.id, input);
     } else {
       // 作成モード
-      const groupId = await createGroup(input);
+      await createGroup(input);
       const updatedGroups = await getAllGroups();
       setGroups(updatedGroups);
-
-      // 新しく作成されたグループを取得
-      const newGroup = updatedGroups.find(g => g.id === groupId);
-      if (newGroup) {
-        addGroup(newGroup);
-      }
     }
   };
 


### PR DESCRIPTION
## 概要
Issue #81で報告されたグループ二重作成バグを修正しました。

## 問題
一度の操作でグループが2個作成されてしまう問題がありました。

## 原因
`Sidebar.tsx`の`handleCreateGroup`関数で、グループ作成後に以下の処理を実行していました：
1. `setGroups(updatedGroups)` - 新規グループを含む全グループを設定
2. `addGroup(newGroup)` - さらに新規グループを追加

この二重処理により、同じグループが2回追加されていました。

## 修正内容
- `setGroups()`で全グループ（新規作成したものを含む）を設定するため、その後の`addGroup()`呼び出しを削除
- 不要になった`addGroup`のimportも削除

## テスト
- [ ] グループ作成が1回のみ実行されることを確認
- [ ] グループ編集が正常に動作することを確認
- [ ] グループ削除が正常に動作することを確認

## 関連Issue
Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)