### PR TITLE
fix: グループ削除/編集後のReact key重複エラーを修正 #83

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,8 +25,6 @@ export default function Sidebar({ isOpen }: SidebarProps) {
   const {
     groups,
     setGroups,
-    updateGroup: updateGroupInStore,
-    removeGroup,
     selectedGroupId,
     setSelectedGroupId,
     setGroupFilteredImageIds,
@@ -43,7 +41,6 @@ export default function Sidebar({ isOpen }: SidebarProps) {
       await updateGroup(input);
       const updatedGroups = await getAllGroups();
       setGroups(updatedGroups);
-      updateGroupInStore(input.id, input);
     } else {
       // 作成モード
       await createGroup(input);
@@ -65,7 +62,10 @@ export default function Sidebar({ isOpen }: SidebarProps) {
     try {
       setIsDeleting(true);
       await deleteGroup(groupId);
-      removeGroup(groupId);
+
+      // 削除後に全グループを再取得して状態を更新
+      const updatedGroups = await getAllGroups();
+      setGroups(updatedGroups);
 
       // 削除したグループが選択されていた場合、選択を解除してフィルターをクリア
       if (selectedGroupId === groupId) {


### PR DESCRIPTION
## 概要
Issue #83で報告されたグループ削除後の挙動不正を修正しました。

## 問題
- グループ削除後、別グループのEdit/Deleteボタンが反応しない
- Reactのコンソールエラー: "Encountered two children with the same key, `4`"

## 原因
`Sidebar.tsx`で、グループの削除・編集時に状態の二重更新が発生していました：

### 1. 編集時の問題
```typescript
await updateGroup(input);
const updatedGroups = await getAllGroups();
setGroups(updatedGroups);           // 全グループを設定
updateGroupInStore(input.id, input); // さらに個別更新（不要）
```

### 2. 削除時の問題
```typescript
await deleteGroup(groupId);
removeGroup(groupId); // ストアから削除
```
`removeGroup()`のみで状態を更新していたため、他の処理との競合でReactのkey管理に不整合が発生していました。

## 修正内容
すべてのグループ操作（作成・編集・削除）で、統一的な状態更新パターンに変更：

1. **編集時**: `updateGroupInStore()`の呼び出しを削除
2. **削除時**: `removeGroup()`の代わりに、`getAllGroups()`で全グループを再取得して`setGroups()`で設定
3. 不要になった`updateGroupInStore`と`removeGroup`のimportを削除

これにより：
- すべての操作で`getAllGroups() → setGroups()`の統一パターン
- 状態の一貫性が保証される
- Reactのkey重複エラーが解消される

## テスト
- [ ] グループ削除後、他のグループのEdit/Deleteボタンが正常に動作することを確認
- [ ] グループ編集が正常に動作することを確認
- [ ] コンソールにReactのkey重複エラーが表示されないことを確認
- [ ] グループ作成が正常に動作することを確認（#81の修正との整合性）

## 関連Issue
Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)