### PR TITLE
fix: サイドバーを画面全体の高さに修正 #80

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
   }, [isSelectionMode, toggleSelectAll, clearSelection, toggleSelectionMode]);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col">
+    <div className="h-screen bg-gray-50 dark:bg-gray-900 transition-colors flex flex-col">
       <Header
         isSidebarOpen={isSidebarOpen}
         onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}


### PR DESCRIPTION
## 概要
Issue #80で報告されたサイドバーの表示が中途半端になっている問題を修正しました。

## 問題
- サイドバーが画面の途中で終わり、一番下まで表示されていなかった
- 画面の一番下まで領域を確保してほしい
- グループが大量にある場合はサイドバー内でスクロールしてほしい

## 原因
`App.tsx`のルート要素で`min-h-screen`を使用していたため、コンテンツが少ない場合に画面高さに満たない可能性がありました。

```tsx
<div className="min-h-screen ...">  // 最小高さ = 画面高さ未満の可能性
```

## 修正内容
`min-h-screen`を`h-screen`に変更し、画面全体を確実に100vh（画面高さ）に固定しました。

```tsx
<div className="h-screen ...">  // 固定高さ = 確実に画面高さ
```

### 変更の影響
- ✅ サイドバーが画面の一番下まで表示される（既存の`h-full`により親要素に追従）
- ✅ グループが多い場合は、サイドバー内の`overflow-y-auto`によりスクロール可能
- ✅ メインコンテンツエリアも`overflow-y-auto`でスクロール可能（既存の動作を維持）

## テスト
- [ ] サイドバーが画面の一番下まで表示されることを確認
- [ ] グループが少ない場合でも正常に表示されることを確認
- [ ] グループが多い場合、サイドバー内でスクロールできることを確認
- [ ] メインコンテンツエリアのスクロールが正常に動作することを確認

## 関連Issue
Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)