### PR TITLE
fix: ドロップダウンメニューの表示位置を動的に調整 #82

### DIFF
--- a/src/components/GroupItem.tsx
+++ b/src/components/GroupItem.tsx
@@ -27,7 +27,9 @@ export default function GroupItem({
   onDelete,
 }: GroupItemProps) {
   const [showMenu, setShowMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<'top' | 'bottom'>('bottom');
   const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   // メニュー外クリックで閉じる
   useEffect(() => {
@@ -45,6 +47,18 @@ export default function GroupItem({
 
   const handleMenuClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    // メニューを開く前に位置を計算
+    if (!showMenu && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const windowHeight = window.innerHeight;
+      const spaceBelow = windowHeight - rect.bottom;
+      const menuHeight = 100; // メニューの概算高さ（2項目）
+
+      // 下部に十分なスペースがない場合は上方向に開く
+      setMenuPosition(spaceBelow < menuHeight ? 'top' : 'bottom');
+    }
+
     setShowMenu(!showMenu);
   };
 
@@ -96,6 +110,7 @@ export default function GroupItem({
       {/* メニューボタン（ホバー時に表示） */}
       <div className="relative" ref={menuRef}>
         <button
+          ref={buttonRef}
           onClick={handleMenuClick}
           className={`p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors ${
             showMenu ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
@@ -107,7 +122,11 @@ export default function GroupItem({
 
         {/* ドロップダウンメニュー */}
         {showMenu && (
-          <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg py-1 z-10 min-w-[120px]">
+          <div
+            className={`absolute right-0 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg py-1 z-10 min-w-[120px] ${
+              menuPosition === 'bottom' ? 'top-full mt-1' : 'bottom-full mb-1'
+            }`}
+          >
             <button
               onClick={handleEdit}
               className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"


### PR DESCRIPTION
## 概要
Issue #82で報告されたサイドバー内のEdit/Deleteメニューが見切れる問題を修正しました。

## 問題
サイドバー内のグループを押下してEdit/Deleteを表示すると、位置によっては画面外に隠れて見えなくなる問題がありました。

![Issue #82 Screenshot](https://github.com/user-attachments/assets/1a3c1475-b771-4d2b-8f7b-0d0502ce9e8d)

## 原因
`GroupItem.tsx`のドロップダウンメニューが常に下方向（`top-full mt-1`）に開く実装だったため、サイドバー下部のグループでメニューを開くと画面外に見切れていました。

## 修正内容
メニューボタンの位置を動的に判定し、開く方向を自動調整する実装に変更：

### 実装詳細
1. **位置判定ロジック**:
   - `buttonRef`でメニューボタンの位置を取得
   - `getBoundingClientRect()`で画面内の座標を計算
   - 下部の残りスペースが100px未満の場合は上方向に開く

2. **状態管理**:
   - `menuPosition`ステート（`'top' | 'bottom'`）で方向を管理
   - メニューを開く前に位置を計算して設定

3. **動的スタイル**:
   ```tsx
   className={`... ${
     menuPosition === 'bottom' ? 'top-full mt-1' : 'bottom-full mb-1'
   }`}
   ```

### 動作
- ✅ サイドバー上部〜中部: 下方向に開く（従来通り）
- ✅ サイドバー下部: 上方向に開く（新機能）
- ✅ 常に画面内にメニューが表示される

## テスト
- [ ] サイドバー上部のグループで、メニューが下方向に正常に開くことを確認
- [ ] サイドバー下部のグループで、メニューが上方向に正常に開くことを確認
- [ ] メニューが常に画面内に表示され、Edit/Deleteボタンが押せることを確認
- [ ] メニュー外クリックで正常に閉じることを確認

## 関連Issue
Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)