### PR TITLE
fix: グループフィルター状態の永続化を無効化

### DIFF
--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -420,7 +420,7 @@ export const useImageStore = create<ImageStore>()(
         sortOrder: state.sortOrder,
         filterSettings: state.filterSettings,
         slideshowInterval: state.slideshowInterval,
-        selectedGroupId: state.selectedGroupId, // グループフィルターを永続化
+        // selectedGroupIdは永続化しない（起動時は常に"All Images"表示）
       }),
     }
   )


### PR DESCRIPTION
## 概要

Issue #89 を修正。`selectedGroupId`を永続化から除外し、アプリ起動時は常に「All Images」表示にすることで、グループフィルター状態の不整合を解消しました。

## 問題

`selectedGroupId`は永続化されるが、`groupFilteredImageIds`は永続化されないため、アプリ再起動時に以下の問題が発生していました：

1. サイドバーでグループが選択状態に見える
2. しかし`groupFilteredImageIds`が空配列のため、画像が表示されない
3. ユーザーが混乱する

### 再現手順（修正前）

1. メインギャラリーでグループを選択してフィルタリング
2. アプリを終了
3. アプリを再起動
4. **結果**: サイドバーでグループが選択状態だが、画像は表示されない

## 修正内容

**ファイル**: `src/store/imageStore.ts`

```diff
 partialize: (state) => ({
   sortBy: state.sortBy,
   sortOrder: state.sortOrder,
   filterSettings: state.filterSettings,
   slideshowInterval: state.slideshowInterval,
-  selectedGroupId: state.selectedGroupId, // グループフィルターを永続化
+  // selectedGroupIdは永続化しない（起動時は常に"All Images"表示）
 }),
```

### 選択した解決策

調査レポートでは3つのオプションが提示されていましたが、**オプション1（`selectedGroupId`を永続化しない）**を選択しました。

**理由**:
- 最もシンプルで安全
- ファイルパスが変更された場合でも問題なし
- 起動時の動作が予測可能（常に「All Images」から開始）
- 非同期処理の複雑さを避けられる

### 他のオプション（不採用）

- **オプション2**: `groupFilteredImageIds`も永続化 → ファイルパスの変更に対応できない
- **オプション3**: 起動時に自動再取得 → 非同期処理が複雑になる

## 影響

### ✅ 改善点

- アプリ起動時のデータとUIの不整合が解消
- ユーザー体験が予測可能になる
- 状態管理がシンプルになる

### ⚠️ 動作変更

- **修正前**: アプリを再起動しても前回のグループフィルターが保持される（ただし動作しない）
- **修正後**: アプリを再起動すると常に「All Images」表示になる

ユーザーは必要に応じて手動でグループを選択する必要がありますが、これは一般的なデスクトップアプリの動作と一致しています。

## テスト

### ✅ 確認項目

- [x] TypeScriptコンパイル成功
- [x] アプリ起動時に「All Images」が表示される
- [x] グループ選択が正常に動作する
- [x] アプリ再起動後も「All Images」表示になる
- [x] 他の永続化された設定（sortBy、filterSettingsなど）は正常に動作する

## 関連Issue

Fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)