### PR TITLE
fix: 選択モードを相互排他的に管理

### DIFF
--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -370,6 +370,9 @@ export const useImageStore = create<ImageStore>()(
           isSelectionMode: !state.isSelectionMode,
           // 選択モード終了時は選択をクリア
           selectedImageIds: state.isSelectionMode ? [] : state.selectedImageIds,
+          // 選択モード開始時は代表画像選択モードをクリア
+          isRepImageSelectionMode: state.isSelectionMode ? state.isRepImageSelectionMode : false,
+          repImageSelectionGroupId: state.isSelectionMode ? state.repImageSelectionGroupId : null,
         })),
       toggleImageSelection: (id) =>
         set((state) => ({
@@ -411,7 +414,13 @@ export const useImageStore = create<ImageStore>()(
 
       // Phase 5: 代表画像選択モード
       setRepImageSelectionMode: (mode, groupId) =>
-        set({ isRepImageSelectionMode: mode, repImageSelectionGroupId: groupId ?? null }),
+        set((state) => ({
+          isRepImageSelectionMode: mode,
+          repImageSelectionGroupId: groupId ?? null,
+          // 代表画像選択モード開始時は複数選択モードをクリア
+          isSelectionMode: mode ? false : state.isSelectionMode,
+          selectedImageIds: mode ? [] : state.selectedImageIds,
+        })),
     }),
     {
       name: 'image-gallery-settings',


### PR DESCRIPTION
## 概要

Issue #90 を修正。`isSelectionMode`（複数選択モード）と`isRepImageSelectionMode`（代表画像選択モード）を相互排他的に管理することで、UI動作の予測可能性を向上させました。

## 問題

2つの選択モードが独立して管理されていたため、両方が同時に有効になる可能性がありました：

### 問題シナリオ1: グループページで複数選択モードが残る
1. メインギャラリーで複数選択モードを有効化（SelectionBarが表示）
2. グループアルバムビューに遷移
3. 「Set Representative Image」をクリック
4. **結果**: SelectionBarと代表画像選択モードが同時に表示され、ユーザーが混乱

### 問題シナリオ2: 画像クリック時の挙動が不明確
- `MediaCard.tsx`では`forceClick`が優先
- `ImageGrid.tsx`では条件分岐が複雑
- ユーザーがクリックした時の動作が予測不可能

## 修正内容

**ファイル**: `src/store/imageStore.ts`

### 1. toggleSelectionMode（368-376行）

複数選択モード**開始時**に代表画像選択モードをクリア：

```typescript
toggleSelectionMode: () =>
  set((state) => ({
    isSelectionMode: !state.isSelectionMode,
    // 選択モード終了時は選択をクリア
    selectedImageIds: state.isSelectionMode ? [] : state.selectedImageIds,
    // 選択モード開始時は代表画像選択モードをクリア（NEW）
    isRepImageSelectionMode: state.isSelectionMode ? state.isRepImageSelectionMode : false,
    repImageSelectionGroupId: state.isSelectionMode ? state.repImageSelectionGroupId : null,
  })),
```

### 2. setRepImageSelectionMode（416-422行）

代表画像選択モード**開始時**に複数選択モードをクリア：

```typescript
setRepImageSelectionMode: (mode, groupId) =>
  set((state) => ({
    isRepImageSelectionMode: mode,
    repImageSelectionGroupId: groupId ?? null,
    // 代表画像選択モード開始時は複数選択モードをクリア（NEW）
    isSelectionMode: mode ? false : state.isSelectionMode,
    selectedImageIds: mode ? [] : state.selectedImageIds,
  })),
```

## ロジックの詳細

### toggleSelectionMode

| 現在の状態 | 操作 | 結果 |
|-----------|------|------|
| `isSelectionMode: false`<br>`isRepImageSelectionMode: true` | toggleSelectionMode() | `isSelectionMode: true`<br>`isRepImageSelectionMode: false` ✅ |
| `isSelectionMode: true` | toggleSelectionMode() | `isSelectionMode: false`<br>（代表画像モードはそのまま） |

### setRepImageSelectionMode

| 現在の状態 | 操作 | 結果 |
|-----------|------|------|
| `isSelectionMode: true`<br>`selectedImageIds: [1, 2, 3]` | setRepImageSelectionMode(true, 10) | `isSelectionMode: false` ✅<br>`selectedImageIds: []` ✅<br>`isRepImageSelectionMode: true` |
| `isRepImageSelectionMode: true` | setRepImageSelectionMode(false, null) | `isRepImageSelectionMode: false`<br>（複数選択モードはそのまま） |

## 影響

### ✅ 改善点

- 2つのモードが相互排他的に動作
- UI動作が予測可能になる
- ユーザーが混乱しない
- モード切り替え時に関連状態も自動クリア

### ⚠️ 動作変更

**シナリオ1**: 複数選択モード中に代表画像選択を開始
- **修正前**: 両方のモードが有効で、UIが混乱
- **修正後**: 複数選択モードが自動で終了し、選択済み画像もクリア

**シナリオ2**: 代表画像選択モード中に複数選択モードを開始
- **修正前**: 両方のモードが有効で、クリック動作が不明確
- **修正後**: 代表画像選択モードが自動で終了

これらは**意図された動作**であり、ユーザー体験の向上につながります。

## テスト

### ✅ 確認項目

- [x] TypeScriptコンパイル成功
- [x] 複数選択モード開始時に代表画像選択モードがクリアされる
- [x] 代表画像選択モード開始時に複数選択モードがクリアされる
- [x] 選択解除時に選択済み画像がクリアされる
- [x] モード終了時に他のモードは影響を受けない

### テストシナリオ

#### シナリオ1: メインギャラリー → グループページ
1. メインギャラリーで複数選択モードを有効化
2. グループアルバムビューに遷移
3. 「Set Representative Image」をクリック
4. **期待結果**: SelectionBarが消え、代表画像選択モードのみが有効

#### シナリオ2: グループページ内でモード切り替え
1. グループアルバムビューで「Set Representative Image」をクリック
2. ESCキーで代表画像選択モードを終了
3. 複数選択モードを開始
4. **期待結果**: 代表画像選択モードの状態がクリアされている

## 関連コンポーネント

この修正により、以下のコンポーネントで一貫したモード管理が実現：
- `SelectionBar.tsx` - 複数選択モード時のUI
- `GroupAlbumView.tsx` - 代表画像選択モード時のUI
- `ImageGrid.tsx` - クリックハンドラー分岐
- `MediaCard.tsx` - forceClickとisSelectionModeの制御

## 関連Issue

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)