### PR TITLE
fix: データベースリセット時にサムネイルも削除してサムネイル不整合を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ npm-debug.log*
 *.db
 *.sqlite
 *.sqlite3
+
+# Other
+.tmp/

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -43,6 +43,7 @@ pub fn backup_database() -> Result<String, String> {
 /**
  * データベースをリセット（削除）します
  * 注意: この操作は元に戻せません
+ * サムネイルディレクトリも同時に削除します
  */
 #[tauri::command]
 pub fn reset_database() -> Result<String, String> {
@@ -57,6 +58,19 @@ pub fn reset_database() -> Result<String, String> {
         .map_err(|e| format!("Failed to delete database: {}", e))?;
 
     println!("Database deleted: {:?}", db_path);
+
+    // サムネイルディレクトリも削除（存在する場合）
+    if let Some(db_dir) = db_path.parent() {
+        let thumbnail_dir = db_dir.join("thumbnails");
+        if thumbnail_dir.exists() {
+            if let Err(e) = fs::remove_dir_all(&thumbnail_dir) {
+                eprintln!("Warning: Failed to delete thumbnails directory: {}", e);
+            } else {
+                println!("Thumbnails directory deleted: {:?}", thumbnail_dir);
+            }
+        }
+    }
+
     Ok("Database reset successfully".to_string())
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -150,8 +150,88 @@ pub fn get_migrations() -> Vec<Migration> {
 }
 
 pub async fn init_db() -> Result<(), String> {
-    let _db_path = get_db_path()?;
-    // データベースディレクトリが作成されたことを確認
+    use rusqlite::Connection;
+
+    let db_path = get_db_path()?;
+    let conn = Connection::open(&db_path)
+        .map_err(|e| format!("Failed to open database: {}", e))?;
+
+    // Migration 1: images テーブル
+    conn.execute_batch("
+        CREATE TABLE IF NOT EXISTS images (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            file_name TEXT NOT NULL,
+            comment TEXT,
+            tags TEXT,
+            rating INTEGER DEFAULT 0,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_file_path ON images(file_path);
+        CREATE INDEX IF NOT EXISTS idx_file_name ON images(file_name);
+    ").map_err(|e| format!("Failed to create images table: {}", e))?;
+
+    // Migration 2-4: カラム追加（既に存在する場合はスキップ）
+    // SQLiteはALTER TABLE ADD COLUMN IF NOT EXISTSをサポートしていないため、
+    // エラーを無視する
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN file_type TEXT DEFAULT 'image'", []);
+    let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_file_type ON images(file_type)", []);
+
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN is_favorite INTEGER DEFAULT 0", []);
+    let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_is_favorite ON images(is_favorite)", []);
+
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN duration_seconds REAL", []);
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN width INTEGER", []);
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN height INTEGER", []);
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN video_codec TEXT", []);
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN audio_codec TEXT", []);
+    let _ = conn.execute("ALTER TABLE images ADD COLUMN thumbnail_path TEXT", []);
+    let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_duration ON images(duration_seconds)", []);
+    let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_resolution ON images(width, height)", []);
+
+    // Migration 5: groups と image_groups テーブル
+    conn.execute_batch("
+        CREATE TABLE IF NOT EXISTS groups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            description TEXT,
+            color TEXT DEFAULT '#3b82f6',
+            representative_image_id INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (representative_image_id) REFERENCES images(id) ON DELETE SET NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_groups_name ON groups(name);
+        CREATE INDEX IF NOT EXISTS idx_groups_created_at ON groups(created_at);
+
+        CREATE TABLE IF NOT EXISTS image_groups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            image_id INTEGER NOT NULL,
+            group_id INTEGER NOT NULL,
+            added_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
+            FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE,
+            UNIQUE(image_id, group_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_image_groups_image ON image_groups(image_id);
+        CREATE INDEX IF NOT EXISTS idx_image_groups_group ON image_groups(group_id);
+    ").map_err(|e| format!("Failed to create groups tables: {}", e))?;
+
+    // Migration 6: group_comments テーブル
+    conn.execute_batch("
+        CREATE TABLE IF NOT EXISTS group_comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            group_id INTEGER NOT NULL,
+            comment TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_group_comments_group ON group_comments(group_id);
+        CREATE INDEX IF NOT EXISTS idx_group_comments_created_at ON group_comments(created_at);
+    ").map_err(|e| format!("Failed to create group_comments table: {}", e))?;
+
+    println!("Database initialization completed");
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,19 +7,8 @@ use commands::*;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  // データベースパスを取得
-  let db_path = db::get_db_path().expect("Failed to get database path");
-  let db_url = format!("sqlite:{}", db_path.to_string_lossy());
-
-  // マイグレーションを取得
-  let migrations = db::get_migrations();
-
   tauri::Builder::default()
-    .plugin(
-      tauri_plugin_sql::Builder::default()
-        .add_migrations(&db_url, migrations)
-        .build()
-    )
+    .plugin(tauri_plugin_sql::Builder::default().build())
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_fs::init())
     .setup(|app| {

--- a/src/components/GroupAlbumView.tsx
+++ b/src/components/GroupAlbumView.tsx
@@ -102,6 +102,7 @@ function GroupAlbumView() {
     try {
       // バックエンドに代表画像を保存
       await setRepresentativeImage(groupId, imageId);
+
       setRepImageSelectionMode(false, null);
       showToast('Representative image set successfully', 'success');
 


### PR DESCRIPTION
## Summary
- データベースリセット時にサムネイルディレクトリも削除するように修正
- サムネイルは `image_id` でファイル名が付けられるため、DBリセット後に同じIDが別のファイルに割り当てられると間違ったサムネイルが表示される問題を解決
- データベース初期化処理を rusqlite で直接実行するように変更（冪等性を確保）
- `tauri_plugin_sql` からマイグレーション登録を削除

## 根本原因
サムネイルは `{image_id}.jpg` という形式で保存されます。データベースをリセットすると、画像が再スキャンされ、新しいIDが割り当てられます。しかし、古いサムネイルファイルが残っているため、異なる動画のサムネイルが表示される問題が発生していました。

## 変更ファイル
- `src-tauri/src/commands.rs` - `reset_database` でサムネイルディレクトリ削除を追加
- `src-tauri/src/db.rs` - マイグレーションを rusqlite で直接実行（冪等性確保）
- `src-tauri/src/lib.rs` - tauri_plugin_sql からマイグレーション登録を削除

## Test plan
- [ ] データベースをリセットする
- [ ] サムネイルディレクトリが削除されていることを確認
- [ ] ディレクトリを再スキャンする
- [ ] 代表画像を設定する
- [ ] 正しいサムネイルが表示されることを確認

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)