### PR TITLE
fix: ページ遷移時に選択モードをリセット

### DIFF
--- a/src/components/GroupAlbumView.tsx
+++ b/src/components/GroupAlbumView.tsx
@@ -23,6 +23,7 @@ function GroupAlbumView() {
     setRepImageSelectionMode,
     showToast,
     updateGroup,
+    resetAllModes,
   } = useImageStore();
 
   const [group, setGroup] = useState<GroupData | null>(null);
@@ -165,7 +166,11 @@ function GroupAlbumView() {
       {/* ヘッダーナビゲーション */}
       <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4">
         <button
-          onClick={() => navigate('/')}
+          onClick={() => {
+            // ページ遷移前にすべてのモード状態をクリア
+            resetAllModes();
+            navigate('/');
+          }}
           className="inline-flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
         >
           <ArrowLeft size={20} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
     setSelectedGroupId,
     setGroupFilteredImageIds,
     showToast,
+    resetAllModes,
   } = useImageStore();
 
   const [showModal, setShowModal] = useState(false);
@@ -97,12 +98,16 @@ export default function Sidebar({ isOpen }: SidebarProps) {
   };
 
   const handleSelectAllImages = () => {
+    // ページ遷移前にすべてのモード状態をクリア
+    resetAllModes();
     navigate('/');
     setSelectedGroupId(null);
     setGroupFilteredImageIds([]);
   };
 
   const handleSelectGroup = (groupId: number) => {
+    // ページ遷移前にすべてのモード状態をクリア
+    resetAllModes();
     // グループアルバムビューに遷移
     navigate(`/group/${groupId}`);
   };

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -173,6 +173,9 @@ interface ImageStore {
   // Phase 5: 代表画像選択モードアクション
   /** 代表画像選択モードを設定します */
   setRepImageSelectionMode: (mode: boolean, groupId?: number | null) => void;
+
+  /** すべての選択モードをリセットします（ページ遷移時に使用） */
+  resetAllModes: () => void;
 }
 
 /**
@@ -421,6 +424,15 @@ export const useImageStore = create<ImageStore>()(
           isSelectionMode: mode ? false : state.isSelectionMode,
           selectedImageIds: mode ? [] : state.selectedImageIds,
         })),
+
+      // ページ遷移時にすべての選択モードをリセット
+      resetAllModes: () =>
+        set({
+          isSelectionMode: false,
+          selectedImageIds: [],
+          isRepImageSelectionMode: false,
+          repImageSelectionGroupId: null,
+        }),
     }),
     {
       name: 'image-gallery-settings',


### PR DESCRIPTION
## Summary
- ページ遷移時にすべての選択モードをクリアするように修正
- `imageStore` に `resetAllModes` 関数を追加
- サイドバーとグループアルバムビューのナビゲーションで `resetAllModes` を呼び出し

## 問題
グループアルバムビューから「All Images」に戻る際、選択モード（`isSelectionMode`、`isRepImageSelectionMode`）がクリアされず、UIが混乱する可能性がありました。

## 変更内容
1. **imageStore.ts**: `resetAllModes()` 関数を追加
   - `isSelectionMode` を `false` に
   - `selectedImageIds` を空配列に
   - `isRepImageSelectionMode` を `false` に
   - `repImageSelectionGroupId` を `null` に

2. **Sidebar.tsx**: 
   - `handleSelectAllImages()` で `resetAllModes()` を呼び出し
   - `handleSelectGroup()` で `resetAllModes()` を呼び出し

3. **GroupAlbumView.tsx**: 
   - 「Back to All Images」ボタンで `resetAllModes()` を呼び出し

## Test plan
- [ ] メインギャラリーで複数選択モードを有効化し、サイドバーから「All Images」をクリック → 選択モードがクリアされる
- [ ] グループアルバムビューで「Set Representative Image」をクリックし、サイドバーから「All Images」をクリック → 代表画像選択モードがクリアされる
- [ ] グループアルバムビューで「Back to All Images」をクリック → すべてのモードがクリアされる
- [ ] サイドバーから別のグループをクリック → すべてのモードがクリアされる

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)