### PR TITLE
fix: 画像グループ追加時のエラーハンドリングを追加

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -349,11 +349,13 @@ pub fn add_images_to_group(image_ids: Vec<i64>, group_id: i64) -> Result<(), Str
         .map_err(|e| format!("Failed to connect to database: {}", e))?;
 
     for image_id in image_ids {
-        // UNIQUE制約により重複挿入は無視される
-        let _ = conn.execute(
+        // UNIQUE制約により重複挿入は無視される（INSERT OR IGNORE）
+        // ただし、その他のエラー（DB接続エラー等）は検出する
+        conn.execute(
             "INSERT OR IGNORE INTO image_groups (image_id, group_id) VALUES (?, ?)",
             rusqlite::params![image_id, group_id],
-        );
+        )
+        .map_err(|e| format!("Failed to add image {} to group: {}", image_id, e))?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- `add_images_to_group` コマンドでエラーを適切に検出するように修正

## 問題
画像をグループに追加する際、`let _ = conn.execute(...)` でエラーを無視していたため、DB接続エラーなどが発生しても検出できませんでした。

## 変更内容

**変更前**:
```rust
let _ = conn.execute(
    "INSERT OR IGNORE INTO image_groups ...",
    ...
);
```

**変更後**:
```rust
conn.execute(
    "INSERT OR IGNORE INTO image_groups ...",
    ...
)
.map_err(|e| format!("Failed to add image {} to group: {}", image_id, e))?;
```

## 動作
- `INSERT OR IGNORE` により重複挿入は引き続き無視される（既存動作維持）
- その他のエラー（DB接続エラー等）は適切にフロントエンドに報告される

## Test plan
- [ ] 画像をグループに追加できることを確認
- [ ] 既にグループに追加済みの画像を再度追加してもエラーにならないことを確認
- [ ] （手動テスト困難）DB接続エラー時にエラーメッセージが表示されることを確認

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)