### PR TITLE
refactor: loadGroupDataをuseCallbackでラップしeslint-disableを削除

### DIFF
--- a/src/components/GroupAlbumView.tsx
+++ b/src/components/GroupAlbumView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { useImageStore } from '../store/imageStore';
@@ -38,7 +38,7 @@ function GroupAlbumView() {
   }, [allImages, group?.representative_image_id]);
 
   // グループデータとグループ内画像を読み込み
-  const loadGroupData = async () => {
+  const loadGroupData = useCallback(async () => {
     if (!groupId) {
       setError('Invalid group ID');
       setIsLoading(false);
@@ -71,12 +71,11 @@ function GroupAlbumView() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [groupId, setError, updateGroup]);
 
   useEffect(() => {
     loadGroupData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupId]);
+  }, [loadGroupData]);
 
   // グループ内の画像のみをフィルタリング
   const groupImages = allImages.filter((img) => groupImageIds.includes(img.id));


### PR DESCRIPTION
## Summary
- `useEffect`の依存配列で`eslint-disable-next-line`を使用していた問題を修正
- `loadGroupData`を`useCallback`でメモ化し、React Hooks規約に準拠

## 変更内容

### Before
```typescript
const loadGroupData = async () => {
  // ...
};

useEffect(() => {
  loadGroupData();
  // eslint-disable-next-line react-hooks/exhaustive-deps
}, [groupId]);
```

### After
```typescript
const loadGroupData = useCallback(async () => {
  // ...
}, [groupId, setError, updateGroup]);

useEffect(() => {
  loadGroupData();
}, [loadGroupData]);
```

## なぜこの変更が必要か

1. **ESLintルール準拠**: `react-hooks/exhaustive-deps`ルールはstale closureやバグを防ぐために設けられている
2. **依存関係の明示化**: `useCallback`の依存配列で、関数が依存する値が明確になる
3. **stale closure防止**: `loadGroupData`が古い値を参照するリスクを排除
4. **メモ化の副次的効果**: `loadGroupData`は`AlbumHeader`の`onGroupUpdated`プロップとしても渡されているため、不要な再生成を防止

## 依存配列の説明

| 依存 | 理由 |
|------|------|
| `groupId` | グループIDが変わったら再取得が必要 |
| `setError` | Zustandのstableな関数（参照不変） |
| `updateGroup` | Zustandのstableな関数（参照不変） |

## Test plan
- [ ] グループアルバムビューが正常に表示される
- [ ] グループ間を遷移するとデータが正しく再読み込みされる
- [ ] グループ情報の更新（名前変更など）後にリロードが正しく動作する
- [ ] ESLint警告が出ないことを確認

Fixes #98

🤖 Generated with [Claude Code](https://claude.ai/code)