### PR TITLE
fix: 画像一覧の並び順が毎回変わる問題を修正

### DIFF
--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -367,6 +367,11 @@ export const useImageStore = create<ImageStore>()(
               break;
           }
 
+          // 同一値の場合、idで安定ソート
+          if (comparison === 0) {
+            comparison = a.id - b.id;
+          }
+
           return sortOrder === 'asc' ? comparison : -comparison;
         });
 

--- a/src/utils/tauri-commands.ts
+++ b/src/utils/tauri-commands.ts
@@ -187,7 +187,7 @@ export async function getAllImages(): Promise<ImageData[]> {
       thumbnail_path: string | null;
       directory_id: number | null;
     }>>(
-      'SELECT id, file_path, file_name, file_type, comment, tags, rating, is_favorite, created_at, updated_at, duration_seconds, width, height, video_codec, audio_codec, thumbnail_path, directory_id FROM images ORDER BY created_at DESC'
+      'SELECT id, file_path, file_name, file_type, comment, tags, rating, is_favorite, created_at, updated_at, duration_seconds, width, height, video_codec, audio_codec, thumbnail_path, directory_id FROM images ORDER BY created_at DESC, id DESC'
     );
 
     // tagsをJSON文字列から配列にパース


### PR DESCRIPTION
## Summary
- SQLクエリに二次ソートキー `id DESC` を追加し、同一秒に登録された画像のDB側の順序を確定化
- フロントエンドのソート（name/created_at/rating）で同一値の場合に `id` でタイブレークし、`Array.sort()` の不安定性を回避
- 画像ディレクトリを複数回表示しても並び順が一貫するように

## Test plan
- [x] `npx tsc --noEmit` — 型チェック通過
- [x] `npm run build` — ビルド成功
- [ ] 同一ディレクトリを複数回表示して並び順が一貫していることを確認
- [ ] 各ソート（名前/日時/評価）で順序が安定していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)