### PR TITLE
refactor: サイドバーUI構造を刷新し全画像表示・ディレクトリ切替を改善

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -10,7 +10,7 @@ export default function EmptyState() {
       <ImageOff size={64} className="mb-4" />
       <h2 className="text-xl font-semibold mb-2 text-gray-700 dark:text-gray-300">No Media Files Found</h2>
       <p className="text-sm">
-        Click "Select Directory" to load images and videos from a folder
+        Add a directory from the sidebar to start browsing images and videos
       </p>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { FolderOpen, Settings, Sun, Moon, Menu, CheckSquare } from 'lucide-react';
+import { Settings, Sun, Moon, Menu, CheckSquare } from 'lucide-react';
 import { useImageStore } from '../store/imageStore';
-import { selectDirectory, scanDirectory, checkFFmpegAvailable } from '../utils/tauri-commands';
+import { checkFFmpegAvailable } from '../utils/tauri-commands';
 import SettingsModal from './SettingsModal';
 import { useTheme } from '../hooks/useTheme';
 import SearchBar from './header/SearchBar';
@@ -17,10 +17,6 @@ type HeaderProps = {
 export default function Header({ isSidebarOpen, onToggleSidebar }: HeaderProps) {
   const {
     images,
-    setImages,
-    setCurrentDirectory,
-    setLoading,
-    setError,
     filterSettings,
     getSortedAndFilteredImages,
     isSelectionMode,
@@ -45,24 +41,6 @@ export default function Header({ isSidebarOpen, onToggleSidebar }: HeaderProps) 
       .then((msg) => console.log('[FFmpeg]', msg))
       .catch((err) => console.warn('[FFmpeg] Not available:', err));
   }, []);
-
-  const handleSelectDirectory = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const path = await selectDirectory();
-      if (path) {
-        const images = await scanDirectory(path);
-        setImages(images);
-        setCurrentDirectory(path);
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      setError(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <>
@@ -139,13 +117,6 @@ export default function Header({ isSidebarOpen, onToggleSidebar }: HeaderProps) 
             title="Settings"
           >
             <Settings size={20} />
-          </button>
-          <button
-            onClick={handleSelectDirectory}
-            className="flex items-center gap-2 bg-blue-500 dark:bg-blue-600 text-white px-3 py-2 rounded hover:bg-blue-600 dark:hover:bg-blue-700 transition-colors"
-          >
-            <FolderOpen size={20} />
-            <span className="hidden sm:inline">Add Dir</span>
           </button>
         </div>
       </header>

--- a/src/components/directory/DirectoryManager.tsx
+++ b/src/components/directory/DirectoryManager.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { FolderPlus, ChevronDown, ChevronRight } from 'lucide-react';
+import { useEffect, useCallback, useState } from 'react';
+import { FolderPlus } from 'lucide-react';
 import {
   getAllDirectories,
   selectAndAddDirectory,
@@ -18,9 +18,15 @@ type DirectoryManagerProps = {
 
 export default function DirectoryManager({ collapsed }: DirectoryManagerProps) {
   const [directories, setDirectories] = useState<DirectoryData[]>([]);
-  const [isExpanded, setIsExpanded] = useState(true);
-  const [selectedDirectoryId, setSelectedDirectoryId] = useState<number | null>(null);
-  const { setImages, setCurrentDirectory, currentDirectory, showToast } = useImageStore();
+  const {
+    setImages,
+    setCurrentDirectory,
+    currentDirectory,
+    selectedDirectoryId,
+    setSelectedDirectoryId,
+    setLoading,
+    showToast,
+  } = useImageStore();
 
   const loadDirectories = useCallback(async () => {
     try {
@@ -50,6 +56,7 @@ export default function DirectoryManager({ collapsed }: DirectoryManagerProps) {
 
   const handleSelectDirectory = useCallback(async (dir: DirectoryData) => {
     try {
+      setLoading(true);
       const images = await getImagesByDirectoryId(dir.id);
       setImages(images);
       setCurrentDirectory(dir.path);
@@ -57,8 +64,10 @@ export default function DirectoryManager({ collapsed }: DirectoryManagerProps) {
     } catch (err) {
       console.error('Failed to load images for directory:', err);
       showToast('Failed to load images', 'error');
+    } finally {
+      setLoading(false);
     }
-  }, [setImages, setCurrentDirectory, showToast]);
+  }, [setImages, setCurrentDirectory, setSelectedDirectoryId, setLoading, showToast]);
 
   const handleAddDirectory = async () => {
     try {
@@ -122,42 +131,27 @@ export default function DirectoryManager({ collapsed }: DirectoryManagerProps) {
   }
 
   return (
-    <div>
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-      >
-        {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        Directories
-        <span className="ml-auto text-xs font-normal normal-case">
-          {directories.filter(d => d.is_active === 1).length}
-        </span>
-      </button>
-
-      {isExpanded && (
-        <div className="px-1 space-y-0.5">
-          {directories.map((dir) => (
-            <div key={dir.id} className="group/dir">
-              <DirectoryItem
-                directory={dir}
-                isSelected={selectedDirectoryId === dir.id}
-                onSelect={() => handleSelectDirectory(dir)}
-                onRemove={() => handleRemove(dir.id)}
-                onToggleActive={() => handleToggleActive(dir)}
-                onRescan={() => handleRescan(dir.id)}
-              />
-            </div>
-          ))}
-
-          <button
-            onClick={handleAddDirectory}
-            className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
-          >
-            <FolderPlus size={14} />
-            Add Directory
-          </button>
+    <div className="px-1 space-y-0.5">
+      {directories.map((dir) => (
+        <div key={dir.id} className="group/dir">
+          <DirectoryItem
+            directory={dir}
+            isSelected={selectedDirectoryId === dir.id}
+            onSelect={() => handleSelectDirectory(dir)}
+            onRemove={() => handleRemove(dir.id)}
+            onToggleActive={() => handleToggleActive(dir)}
+            onRescan={() => handleRescan(dir.id)}
+          />
         </div>
-      )}
+      ))}
+
+      <button
+        onClick={handleAddDirectory}
+        className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+      >
+        <FolderPlus size={14} />
+        Add Directory
+      </button>
     </div>
   );
 }

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -117,6 +117,9 @@ interface ImageStore {
   /** 代表画像選択中のグループID */
   repImageSelectionGroupId: number | null;
 
+  /** 選択されたディレクトリID（nullは全画像表示） */
+  selectedDirectoryId: number | null;
+
   /** 画像データの配列を設定します */
   setImages: (images: ImageData[]) => void;
   /** 現在のディレクトリパスを設定します */
@@ -200,6 +203,9 @@ interface ImageStore {
   /** 代表画像選択モードを設定します */
   setRepImageSelectionMode: (mode: boolean, groupId?: number | null) => void;
 
+  /** 選択されたディレクトリIDを設定します */
+  setSelectedDirectoryId: (id: number | null) => void;
+
   /** すべての選択モードをリセットします（ページ遷移時に使用） */
   resetAllModes: () => void;
 }
@@ -246,6 +252,8 @@ export const useImageStore = create<ImageStore>()(
       // Phase 5: 代表画像選択モード
       isRepImageSelectionMode: false,
       repImageSelectionGroupId: null,
+
+      selectedDirectoryId: null,
 
       setImages: (images) => set({ images }),
       setCurrentDirectory: (path) => set({ currentDirectory: path }),
@@ -465,6 +473,8 @@ export const useImageStore = create<ImageStore>()(
           isSelectionMode: mode ? false : state.isSelectionMode,
           selectedImageIds: mode ? [] : state.selectedImageIds,
         })),
+
+      setSelectedDirectoryId: (id) => set({ selectedDirectoryId: id }),
 
       // ページ遷移時にすべての選択モードをリセット
       resetAllModes: () =>


### PR DESCRIPTION
## Summary

- サイドバーを **DIRECTORIES** / **GROUPS** の2セクション構成に再構成
- `selectedDirectoryId` を Zustand store に追加し、ディレクトリ選択状態を一元管理（ローカル state 廃止）
- 「All Images」クリックで全画像を DB からリロードし、全表示に確実に戻れるように修正
- Header の「Add Dir」ボタンを削除し、ディレクトリ追加をサイドバーに集約
- MainGallery の初期ロードで `selectedDirectoryId` に応じた画像取得を追加
- EmptyState / ImageGrid の表示条件を `currentDirectory` から `images.length` ベースに変更

## 変更ファイル（6ファイル）

| ファイル | 変更内容 |
|----------|----------|
| `src/store/imageStore.ts` | `selectedDirectoryId` / `setSelectedDirectoryId` 追加 |
| `src/components/Sidebar.tsx` | DIRECTORIES/GROUPS セクション構成に刷新 |
| `src/components/directory/DirectoryManager.tsx` | ローカル state → store 管理、折りたたみヘッダー削除 |
| `src/components/Header.tsx` | Add Dir ボタン・関連ロジック削除 |
| `src/components/MainGallery.tsx` | 初期画像ロード追加、表示条件修正 |
| `src/components/EmptyState.tsx` | テキストをサイドバー案内に変更 |

## Test plan

- [ ] 起動時に全画像が自動表示されること
- [ ] サイドバーのディレクトリクリック → そのディレクトリの画像のみ表示
- [ ] 「All Images」クリック → 全画像表示に戻ること
- [ ] グループ選択 → グループアルバム表示
- [ ] グループから戻る → 直前のディレクトリ選択状態が維持されること
- [ ] Header に Add Dir ボタンが表示されないこと
- [ ] ダークモードで正常表示
- [ ] `npx tsc --noEmit` 通過
- [ ] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)