### PR TITLE
docs: CLAUDE.mdにコードレビュー観点を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ Co-Authored-By: Claude <model> <noreply@anthropic.com>
 
 ## コードレビュー観点
 
+**レビューコメントはすべて日本語で記述すること。**
+
 ### Critical（必ず検出すべき問題）
 - `any` 型の使用、`interface` の使用（`type` を優先）、クラスコンポーネントの使用
 - `dark:` プレフィックスの付け忘れ（全コンポーネントでダークモード対応必須）


### PR DESCRIPTION
## Summary

- CLAUDE.md に「コードレビュー観点」セクションを追加
- code-review プラグインが CLAUDE.md を自動参照するため、PR 自動レビュー時に反映される
- Critical / Warning / Ignore の3段階で観点を整理

## 追加内容

| レベル | 内容 |
|--------|------|
| **Critical** | `any`型、ダークモード漏れ、Tailwind v3混入、Store直接変更、Tauriコマンド未登録、セキュリティ |
| **Warning** | 100行超コンポーネント、型パラメータ欠如、命名規約、Store整合性 |
| **Ignore** | 既存コードのスタイル、linter検出済み問題、ドキュメント不足 |

## Test plan

- [ ] `claude-code-review.yml` ワークフローの変更なし（既存設定で動作）
- [ ] CLAUDE.md が正しく読めること

🤖 Generated with [Claude Code](https://claude.com/claude-code)