### PR TITLE
docs: プロジェクトドキュメントを最新化・強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **メディアファイル管理**: ディレクトリをスキャンして画像・動画を一覧表示
 - **動画対応**: MP4/WebM/MOV動画の再生、自動サムネイル生成、メタデータ抽出（長さ・解像度・コーデック情報）、カスタムプレイヤー
-- **メタデータ編集**: コメント、タグ、評価の追加・編集
+- **メタデータ編集**: コメント、タグ（オートコンプリート付き）、評価の追加・編集
 - **お気に入り機能**: 画像・動画をお気に入りに登録して一覧表示
 - **検索・フィルタリング**:
   - ファイル名による検索
@@ -14,12 +14,19 @@
   - 評価フィルター（最低評価値の設定）
   - タグフィルター（AND/OR検索モード対応）
   - お気に入りのみ表示
+- **表示モード**: グリッド / リスト / タイムライン（年月別グルーピング）、グリッド密度設定（compact/normal/comfortable）
+- **仮想スクロール**: 大量の画像・動画でも快適に閲覧（VirtualGrid / VirtualList）
 - **ソート機能**: 名前、作成日時、評価による並び替え（昇順/降順）
-- **ダークモード**: システム設定に応じた自動切り替え、手動トグル機能
-- **レスポンシブ対応**: モバイル、タブレット、デスクトップに最適化されたUI（開発時のプレビューに対応）
+- **グループ管理**: グループの作成/編集/削除、画像の複数選択→グループ追加、代表画像設定、D&Dによる並べ替え
+- **グループアルバムビュー**: グループ内の画像一覧表示、コメント機能
+- **マルチディレクトリ管理**: 複数ディレクトリの追加/削除/有効無効切替/リスキャン、ファイルウォッチャーによる自動検出
+- **Undo/Redo**: メタデータ編集操作の取り消し・やり直し
+- **エクスポート/インポート**: メタデータのJSON/CSV形式でのエクスポート、JSONからのインポート
 - **スライドショー**: 自動再生、速度調整（3秒/5秒/10秒）、前後スキップ
+- **ダークモード**: システム設定に応じた自動切り替え、手動トグル機能
+- **レスポンシブ対応**: モバイル、タブレット、デスクトップに最適化されたUI
 - **データ永続化**: SQLiteによるメタデータ管理
-- **エラーハンドリング**: メディアファイル読み込みエラーの適切な処理
+- **テスト基盤**: Vitest + React Testing Library によるユニットテスト
 
 ## サポートフォーマット
 
@@ -51,6 +58,13 @@
 - tauri-plugin-dialog (ディレクトリ選択)
 - tauri-plugin-fs (ファイルシステムアクセス)
 - ffmpeg/ffprobe (動画メタデータ抽出、サムネイル生成)
+
+### テスト
+- Vitest (テストランナー)
+- React Testing Library (コンポーネントテスト)
+- happy-dom (ブラウザ環境)
+
+詳細なアーキテクチャについては [doc/architecture.md](./doc/architecture.md) を参照してください。
 
 ## 開発環境のセットアップ
 
@@ -102,14 +116,53 @@ npm run tauri:build
 
 ```
 image-gallery/                     # リポジトリルート
-├── doc/                           # ドキュメント（プロジェクト計画・要件定義）
+├── doc/                           # ドキュメント
+│   ├── architecture.md            # アーキテクチャ概要
+│   ├── er-diagram.md              # ER図（Mermaid）
+│   └── commands-reference.md      # Tauriコマンドリファレンス
 ├── src/                           # React フロントエンドコード
+│   ├── __mocks__/                 # Tauriモック（テスト用）
 │   ├── components/                # UIコンポーネント
-│   │   ├── Header                 # ヘッダー（ディレクトリ選択、統計表示）
-│   │   ├── ImageGrid              # グリッド表示
-│   │   ├── MediaCard              # メディアカード（画像/動画）
+│   │   ├── detail/                # 詳細表示関連
+│   │   │   ├── ImageViewer        # 画像・動画ビューア
+│   │   │   ├── MetadataPanel      # メタデータ編集パネル
+│   │   │   ├── TagAutocomplete    # タグオートコンプリート
+│   │   │   └── RatingStars        # 評価星
+│   │   ├── grid/                  # グリッド・リスト表示
+│   │   │   ├── VirtualGrid        # 仮想スクロールグリッド
+│   │   │   ├── VirtualList        # 仮想スクロールリスト
+│   │   │   ├── TimelineView       # タイムラインビュー
+│   │   │   └── ListItem           # リスト項目
+│   │   ├── header/                # ヘッダー関連
+│   │   │   ├── SearchBar          # 検索バー
+│   │   │   ├── FilterPanel        # フィルターパネル
+│   │   │   ├── SortControls       # ソートコントロール
+│   │   │   └── ViewModeToggle     # 表示モード切替
+│   │   ├── directory/             # ディレクトリ管理
+│   │   │   ├── DirectoryManager   # ディレクトリ管理パネル
+│   │   │   └── DirectoryItem      # ディレクトリ項目
+│   │   ├── dnd/                   # ドラッグ&ドロップ
+│   │   │   ├── DndProvider        # D&Dプロバイダー
+│   │   │   └── DragOverlay        # ドラッグオーバーレイ
+│   │   ├── settings/              # 設定関連
+│   │   │   ├── ExportSection      # エクスポート
+│   │   │   └── ImportSection      # インポート
+│   │   ├── Header                 # ヘッダー
+│   │   ├── Sidebar                # サイドバー
+│   │   ├── MainGallery            # メインギャラリー
+│   │   ├── ImageGrid              # メディアグリッド
+│   │   ├── MediaCard              # メディアカード
 │   │   ├── ImageDetail            # 詳細モーダル
 │   │   ├── VideoPlayer            # カスタム動画プレイヤー
+│   │   ├── GroupModal             # グループ作成・編集モーダル
+│   │   ├── GroupAlbumView         # グループアルバムビュー
+│   │   ├── GroupItem              # グループ項目
+│   │   ├── GroupComments          # グループコメント
+│   │   ├── AlbumHeader            # アルバムヘッダー
+│   │   ├── Breadcrumb             # パンくずナビ
+│   │   ├── SelectionBar           # 選択モードバー
+│   │   ├── UndoRedoBar            # Undo/Redoバー
+│   │   ├── Toast                  # トースト通知
 │   │   ├── SettingsModal          # 設定モーダル
 │   │   ├── SlideshowControls      # スライドショーコントロール
 │   │   ├── ErrorBoundary          # エラーバウンダリ
@@ -118,34 +171,61 @@ image-gallery/                     # リポジトリルート
 │   ├── hooks/                     # カスタムフック
 │   │   └── useTheme               # テーマ管理フック
 │   ├── store/                     # Zustand状態管理
+│   │   └── __tests__/             # ストアテスト
 │   ├── types/                     # TypeScript型定義
 │   ├── utils/                     # ユーティリティ関数
+│   │   └── tauri-commands         # Tauri APIラッパー
 │   ├── App                        # アプリケーションルート
 │   ├── index                      # グローバルスタイル（Tailwind設定）
 │   └── main                       # エントリーポイント
 ├── src-tauri/                     # Tauri バックエンドコード（Rust）
 │   ├── src/
 │   │   ├── main                   # エントリーポイント
+│   │   ├── lib                    # プラグイン初期化・コマンド登録
 │   │   ├── commands               # Tauriコマンド定義
-│   │   ├── db                     # データベース管理
+│   │   ├── db                     # データベース管理・マイグレーション
 │   │   ├── fs_utils               # ファイルシステムユーティリティ
-│   │   └── video_utils            # 動画処理（ffmpeg統合、メタデータ抽出、サムネイル生成）
+│   │   ├── video_utils            # 動画処理（ffmpeg統合）
+│   │   └── watcher                # ファイルウォッチャー
 │   └── tauri.conf                 # Tauri設定
 ├── CLAUDE                         # Claude Code 開発ガイド
 ├── README                         # このファイル
 ├── package.json                   # npm設定
-└── vite.config                    # Vite設定
+├── vite.config                    # Vite設定
+└── vitest.setup                   # テストセットアップ
 ```
 
 ## 使い方
 
-1. **ディレクトリを選択**: 「Select Directory」ボタンをクリックして、画像・動画が含まれるフォルダを選択
-2. **メディアを閲覧**: グリッド表示で一覧を確認。動画には再生アイコンが表示されます
+### 基本操作
+
+1. **ディレクトリを追加**: サイドバーの「ディレクトリ追加」ボタンから画像・動画が含まれるフォルダを選択
+2. **メディアを閲覧**: グリッド/リスト/タイムラインビューで一覧を確認
 3. **詳細を表示**: メディアをクリックして詳細モーダルを開く
    - 画像: 高品質プレビュー表示
    - 動画: カスタムプレイヤーで再生（再生/一時停止、シーク、音量、フルスクリーン対応）
-4. **メタデータを編集**: 詳細モーダルでコメント、タグ、評価を追加・編集
+4. **メタデータを編集**: 詳細モーダルでコメント、タグ（オートコンプリート付き）、評価を追加・編集
 5. **ナビゲーション**: 前へ/次へボタンで他のメディアに移動
+
+### グループ管理
+
+1. **グループ作成**: サイドバーの「+」ボタンからグループを作成（名前・色・説明を設定）
+2. **画像をグループに追加**: 選択モードで画像を複数選択し、グループに追加
+3. **アルバムビュー**: グループをクリックしてアルバムビューを開く
+4. **代表画像設定**: アルバムビュー内で代表画像を設定
+5. **コメント**: アルバムビューでグループにコメントを追加
+
+### マルチディレクトリ管理
+
+1. **ディレクトリ追加**: サイドバーのディレクトリ管理から複数のディレクトリを追加
+2. **有効/無効切替**: ディレクトリごとに表示の有効/無効を切り替え
+3. **リスキャン**: 個別または全ディレクトリを再スキャン
+4. **ファイルウォッチャー**: ディレクトリ内のファイル変更を自動検出
+
+### エクスポート/インポート
+
+1. **エクスポート**: 設定 → エクスポートから JSON または CSV 形式で出力
+2. **インポート**: 設定 → インポートから JSON ファイルを読み込み（メタデータとグループを復元）
 
 ## 開発コマンド
 
@@ -158,8 +238,14 @@ npm run tauri:dev          # フロントエンド + Tauri
 npm run build              # フロントエンドビルド
 npm run tauri:build        # アプリケーション全体のビルド
 
-# リント
+# テスト
+npm run test               # テスト実行
+npm run test:watch         # ウォッチモード
+npm run test:coverage      # カバレッジレポート
+
+# リント・型チェック
 npm run lint               # ESLintチェック
+npx tsc --noEmit           # TypeScript型チェック
 
 # Tauriコマンド
 npm run tauri -- [command] # Tauri CLIの実行
@@ -173,42 +259,25 @@ npm run tauri -- [command] # Tauri CLIの実行
 ~/Library/Application Support/com.imagegallery/gallery.db
 ```
 
-**注意**: 旧バージョン（v0.1.0以前）では `~/.image_gallery/gallery.db` にデータベースが保存されていました。アプリケーションは初回起動時に自動的に新しい場所へ移行します。
+### データベース設計
 
-### データベーススキーマ
+6テーブル構成: `images`, `directories`, `groups`, `image_groups`, `group_comments`, `action_log`
 
-```sql
-CREATE TABLE images (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    file_path TEXT NOT NULL UNIQUE,
-    file_name TEXT NOT NULL,
-    file_type TEXT DEFAULT 'image',  -- 'image' または 'video'
-    comment TEXT,
-    tags TEXT,                        -- JSON配列形式
-    rating INTEGER DEFAULT 0,         -- 0-5
-    is_favorite INTEGER DEFAULT 0,    -- 0: 通常, 1: お気に入り
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+詳細なER図とスキーマは [doc/er-diagram.md](./doc/er-diagram.md) を参照してください。
 
-    -- Phase 3: 動画メタデータ（v4で追加）
-    duration_seconds REAL,            -- 動画の長さ（秒）
-    width INTEGER,                    -- 解像度（幅）
-    height INTEGER,                   -- 解像度（高さ）
-    video_codec TEXT,                 -- ビデオコーデック
-    audio_codec TEXT,                 -- オーディオコーデック
-    thumbnail_path TEXT               -- サムネイル画像パス
-);
-```
+### マイグレーション履歴
 
-### データベースのマイグレーション
+アプリケーションは起動時に自動的にデータベースマイグレーションを実行します。
 
-アプリケーションは起動時に自動的にデータベースマイグレーションを実行します。新しいバージョンにアップデートした際、データベーススキーマが自動的に更新されます。
-
-**マイグレーション履歴:**
-- Version 1: 初期テーブル作成
-- Version 2: `file_type`カラム追加（MP4動画対応）
-- Version 3: `is_favorite`カラム追加（お気に入り機能）
-- Version 4: 動画メタデータカラム追加（`duration_seconds`, `width`, `height`, `video_codec`, `audio_codec`, `thumbnail_path`）、WebM/MOV対応
+| Version | 説明 | Phase |
+|---------|------|-------|
+| v1 | 初期テーブル作成（images） | Phase 1 |
+| v2 | `file_type` カラム追加（動画対応） | Phase 2 |
+| v3 | `is_favorite` カラム追加（お気に入り機能） | Phase 2 |
+| v4 | 動画メタデータカラム追加（duration, resolution, codecs, thumbnail） | Phase 3 |
+| v5 | `groups` + `image_groups` テーブル追加（グループ管理） | Phase 4 |
+| v6 | `group_comments` テーブル追加（コメント機能） | Phase 5 |
+| v7 | `directories` + `action_log` テーブル追加、`images.directory_id` 追加 | Phase 6 |
 
 ### データベースのバックアップ
 
@@ -321,20 +390,20 @@ rm ~/Library/Application\ Support/com.imagegallery/gallery.db
    npm run tauri:dev
    ```
 
+## ドキュメント
+
+| ドキュメント | 内容 |
+|-------------|------|
+| [CLAUDE.md](./CLAUDE.md) | Claude Code 開発ガイド |
+| [doc/architecture.md](./doc/architecture.md) | アーキテクチャ概要・システム構成図 |
+| [doc/er-diagram.md](./doc/er-diagram.md) | ER図・マイグレーション履歴 |
+| [doc/commands-reference.md](./doc/commands-reference.md) | 全Tauriコマンドリファレンス |
+
 ## 開発者向け情報
 
 ### Claude Codeでの開発
 
 このプロジェクトはClaude Codeでの開発に最適化されています。開発を始める前に **[CLAUDE.md](./CLAUDE.md)** を必ずお読みください。
-
-**CLAUDEガイドの内容:**
-- プロジェクト構造の詳細説明
-- Tailwind CSS v4の重要な注意点
-- ダークモード対応のガイドライン
-- コーディング規約
-- 開発ワークフロー
-- トラブルシューティング
-- Claude Codeとの協働のコツ
 
 ### 開発ワークフロー
 

--- a/doc/11_phase7-completed.md
+++ b/doc/11_phase7-completed.md
@@ -1,0 +1,108 @@
+# Phase 7 完了報告: タグオートコンプリート・タイムラインビュー・テスト基盤
+
+## 概要
+
+Phase 7 では、使い勝手の向上（タグオートコンプリート）、新しい閲覧体験（タイムラインビュー）、品質基盤（テスト）の3方向で強化を実施した。
+
+**実装順序**: テスト基盤 → タグオートコンプリート → タイムラインビュー
+
+---
+
+## Issue 1: テスト基盤構築（Vitest）
+
+### 実装内容
+
+Vitest + React Testing Library + happy-dom でテスト環境を構築。Tauri API のモック基盤を整備し、`imageStore` と `useTheme` の初期テストを作成。
+
+### 変更ファイル
+
+| ファイル | 操作 | 内容 |
+|----------|------|------|
+| `package.json` | 修正 | テスト依存追加 + `test`/`test:watch`/`test:coverage` スクリプト |
+| `vite.config.ts` | 修正 | `test` 設定追加（happy-dom, globals, setupFiles） |
+| `tsconfig.app.json` | 修正 | `types` に `vitest/globals` 追加 |
+| `vitest.setup.ts` | 新規 | jest-dom マッチャー + localStorage/matchMedia モック |
+| `src/__mocks__/@tauri-apps/api/core.ts` | 新規 | `invoke`/`convertFileSrc` モック |
+| `src/__mocks__/@tauri-apps/plugin-sql.ts` | 新規 | Database モック |
+| `src/__mocks__/@tauri-apps/plugin-dialog.ts` | 新規 | ダイアログモック |
+| `src/store/__tests__/imageStore.test.ts` | 新規 | ストアテスト（ソート・フィルタ・タグ・選択） |
+| `src/hooks/__tests__/useTheme.test.ts` | 新規 | テーマフックテスト |
+
+### テストカバレッジ
+
+- **imageStore**: ソート（name/created_at/rating × asc/desc）、フィルタ（fileType/minRating/favorites/searchQuery/tags/group/複合）、タグ取得、選択モード、基本操作
+- **useTheme**: デフォルト値、localStorage読み書き、dark/lightクラス制御、resolvedTheme
+
+### 実行コマンド
+
+```bash
+npm run test          # 全テスト実行
+npm run test:watch    # ウォッチモード
+npm run test:coverage # カバレッジレポート
+```
+
+---
+
+## Issue 2: タグオートコンプリート
+
+### 実装内容
+
+タグ入力時に既存タグを候補表示するオートコンプリート機能。`MetadataPanel` のタグ入力を `TagAutocomplete` コンポーネントに置換。バックエンド変更なし。
+
+### 変更ファイル
+
+| ファイル | 操作 | 内容 |
+|----------|------|------|
+| `src/components/detail/TagAutocomplete.tsx` | 新規 | オートコンプリート入力 + ドロップダウン |
+| `src/components/detail/MetadataPanel.tsx` | 修正 | タグ入力を TagAutocomplete に置換 |
+
+### 機能詳細
+
+- 既存タグの部分一致サジェスト（大文字小文字無視）
+- 画像に既設定のタグはサジェストから除外
+- 最大10件表示
+- キーボード操作: ↑↓でハイライト移動、Enterで選択/新規作成、Escapeで閉じる
+- マウスクリックでサジェスト選択
+- ダークモード対応
+
+---
+
+## Issue 3: タイムラインビュー
+
+### 実装内容
+
+画像を `created_at` の年月でグルーピングし、sticky ヘッダー付きのセクションとして表示する新しいビューモード。
+
+### 変更ファイル
+
+| ファイル | 操作 | 内容 |
+|----------|------|------|
+| `src/store/imageStore.ts` | 修正 | `ViewMode` に `'timeline'` 追加 |
+| `src/types/image.ts` | 修正 | `DateGroup` 型追加 |
+| `src/components/grid/TimelineView.tsx` | 新規 | タイムラインビューコンポーネント |
+| `src/components/header/ViewModeToggle.tsx` | 修正 | Calendar アイコン + timeline ボタン追加 |
+| `src/components/ImageGrid.tsx` | 修正 | `viewMode === 'timeline'` 分岐追加 |
+
+### 機能詳細
+
+- 年月セクションヘッダー（画像数表示付き）
+- sticky ヘッダー（スクロール時に固定、backdrop-blur）
+- グリッド密度設定に追従
+- ソート順（asc/desc）でセクション順が反転
+- フィルター適用時にフィルタ済み画像のみグルーピング
+- 選択モード対応
+- 仮想化なし（`loading="lazy"` による遅延読み込み）
+
+---
+
+## 関連PR
+
+- テスト基盤: #115
+- タグオートコンプリート: #117
+- タイムラインビュー: #119
+- ディレクトリ追加時の画像表示修正: #118
+- TagAutocomplete のライトモード対応修正: #120
+
+## 完了日
+
+2026年2月

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,236 @@
+# アーキテクチャ概要
+
+Image Gallery Manager のシステム構成と設計を説明するドキュメント。
+
+## 技術スタック
+
+| レイヤー | 技術 | バージョン |
+|----------|------|-----------|
+| フロントエンド | React + TypeScript | React 19 |
+| ビルドツール | Vite | 7 |
+| スタイリング | Tailwind CSS | v4 |
+| 状態管理 | Zustand (persist) | — |
+| ルーティング | React Router | v7 |
+| アイコン | lucide-react | — |
+| デスクトップ | Tauri | v2 |
+| バックエンド | Rust | — |
+| データベース | SQLite (tauri-plugin-sql) | — |
+| 動画処理 | ffmpeg / ffprobe | — |
+
+## システム構成図
+
+```mermaid
+flowchart TB
+    subgraph Frontend["フロントエンド (React 19 + TypeScript)"]
+        direction TB
+        UI["UIコンポーネント"]
+        Store["Zustand Store<br/>(imageStore)"]
+        Commands["tauri-commands.ts<br/>(APIラッパー)"]
+        UI --> Store
+        UI --> Commands
+    end
+
+    subgraph Backend["バックエンド (Rust / Tauri v2)"]
+        direction TB
+        CmdRS["commands.rs<br/>(API層 + バリデーション)"]
+        DB["db.rs<br/>(初期化・マイグレーション)"]
+        FS["fs_utils.rs<br/>(ファイルスキャン)"]
+        Video["video_utils.rs<br/>(ffmpeg連携)"]
+        Watcher["watcher.rs<br/>(ファイル監視)"]
+    end
+
+    subgraph External["外部リソース"]
+        SQLite[(SQLite DB)]
+        FileSystem[("ファイルシステム<br/>(画像・動画)")]
+        FFmpeg["ffmpeg / ffprobe"]
+    end
+
+    Commands -->|"Tauri IPC<br/>(invoke)"| CmdRS
+    Commands -->|"tauri-plugin-sql<br/>(直接SQL)"| SQLite
+    CmdRS --> DB
+    CmdRS --> FS
+    CmdRS --> Video
+    DB --> SQLite
+    FS --> FileSystem
+    Video --> FFmpeg
+    Watcher --> FileSystem
+    Watcher -->|"イベント発火"| Frontend
+```
+
+## フロントエンド構造
+
+### コンポーネントツリー
+
+```
+App (React Router)
+├── MainGallery                    メインギャラリー画面
+│   ├── Sidebar                    サイドバー（グループ一覧・ディレクトリ管理）
+│   │   ├── GroupItem              グループ項目
+│   │   └── directory/
+│   │       ├── DirectoryManager   ディレクトリ管理パネル
+│   │       └── DirectoryItem      ディレクトリ項目
+│   ├── Header                     ヘッダー
+│   │   ├── header/SearchBar       検索バー
+│   │   ├── header/FilterPanel     フィルターパネル
+│   │   ├── header/SortControls    ソートコントロール
+│   │   └── header/ViewModeToggle  表示モード切替
+│   ├── ImageGrid                  メディアグリッド（表示モード分岐）
+│   │   ├── grid/VirtualGrid       仮想スクロールグリッド
+│   │   ├── grid/VirtualList       仮想スクロールリスト
+│   │   ├── grid/TimelineView      タイムラインビュー
+│   │   └── grid/ListItem          リスト項目
+│   ├── MediaCard                  メディアカード
+│   ├── ImageDetail                詳細モーダル
+│   │   ├── detail/ImageViewer     画像・動画ビューア
+│   │   ├── detail/MetadataPanel   メタデータ編集パネル
+│   │   ├── detail/TagAutocomplete タグオートコンプリート
+│   │   └── detail/RatingStars     評価星
+│   ├── SelectionBar               選択モードバー
+│   ├── UndoRedoBar                Undo/Redoバー
+│   ├── Toast                      トースト通知
+│   ├── SlideshowControls          スライドショー
+│   └── GroupModal                 グループ作成・編集モーダル
+├── GroupAlbumView                 グループアルバム画面
+│   ├── AlbumHeader                アルバムヘッダー
+│   ├── Breadcrumb                 パンくずナビ
+│   └── GroupComments              コメント機能
+├── SettingsModal                  設定モーダル
+│   ├── settings/ExportSection     エクスポート
+│   └── settings/ImportSection     インポート
+├── dnd/DndProvider                ドラッグ&ドロップ
+├── dnd/DragOverlay                ドラッグオーバーレイ
+├── ErrorBoundary                  エラーバウンダリ
+├── EmptyState                     空状態表示
+├── LoadingSpinner                 ローディング表示
+└── VideoPlayer                    カスタム動画プレイヤー
+```
+
+### 状態管理
+
+`src/store/imageStore.ts` で Zustand + persist を使用。
+
+**主な状態:**
+
+| カテゴリ | 状態 | 説明 |
+|----------|------|------|
+| データ | `images` | 画像・動画データ配列 |
+| データ | `groups` | グループデータ配列 |
+| データ | `directories` | ディレクトリデータ配列 |
+| 表示 | `viewMode` | grid / list / timeline |
+| 表示 | `gridDensity` | compact / normal / comfortable |
+| フィルタ | `searchQuery` | 検索文字列 |
+| フィルタ | `fileTypeFilter` | all / image / video |
+| フィルタ | `minRating` | 最低評価値 |
+| フィルタ | `selectedTags` | タグフィルター |
+| フィルタ | `tagFilterMode` | any / all |
+| ソート | `sortBy` | name / created_at / rating |
+| ソート | `sortOrder` | asc / desc |
+| 選択 | `selectionMode` | 選択モードON/OFF |
+| 選択 | `selectedImageIds` | 選択中の画像ID |
+| テーマ | `theme` | light / dark / system |
+
+### ルーティング
+
+```
+/           → MainGallery（メインギャラリー）
+/album/:id  → GroupAlbumView（グループアルバム）
+```
+
+## バックエンド構造
+
+### モジュール構成
+
+| ファイル | 役割 |
+|----------|------|
+| `main.rs` | エントリーポイント（`lib::run()` 呼び出しのみ） |
+| `lib.rs` | プラグイン初期化・全コマンド登録・WatcherState管理 |
+| `commands.rs` | Tauriコマンド定義（API層 + 入力バリデーション） |
+| `db.rs` | DB初期化・マイグレーション定義・DBパス管理 |
+| `fs_utils.rs` | ファイルスキャン・拡張子判定（walkdir使用） |
+| `video_utils.rs` | ffmpeg/ffprobe連携（メタデータ抽出・サムネイル生成） |
+| `watcher.rs` | ファイルウォッチャー（notify使用） |
+
+### コマンド呼び出しの2パターン
+
+1. **Tauri IPC（`invoke`）**: Rustコマンドを直接呼び出し。グループ管理、ディレクトリ管理、Undo/Redo、エクスポート/インポートなど
+2. **tauri-plugin-sql（直接SQL）**: フロントエンドからSQLiteに直接アクセス。画像CRUDの一部（`getAllImages`, `updateImageMetadata`など）
+
+## データフロー
+
+### ディレクトリスキャン → 画像表示
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant UI as フロントエンド
+    participant CMD as tauri-commands.ts
+    participant Rust as commands.rs
+    participant FS as fs_utils.rs
+    participant DB as SQLite
+
+    User->>UI: ディレクトリ選択
+    UI->>CMD: selectDirectory()
+    CMD->>Rust: invoke('select_directory')
+    Rust-->>CMD: ディレクトリパス
+    CMD->>Rust: invoke('scan_directory', {path})
+    Rust->>FS: scan_images_in_directory()
+    FS-->>Rust: ファイルパス一覧
+    Rust-->>CMD: ImageFileInfo[]
+    CMD->>DB: INSERT INTO images (直接SQL)
+    CMD->>DB: SELECT * FROM images
+    DB-->>CMD: 画像データ
+    CMD-->>UI: ImageData[]
+    UI->>UI: Store更新 → 再レンダリング
+```
+
+### メタデータ編集
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant UI as 詳細モーダル
+    participant CMD as tauri-commands.ts
+    participant DB as SQLite
+    participant Undo as action_log
+
+    User->>UI: 評価/タグ/コメント変更
+    UI->>CMD: logAction(旧値, 新値)
+    CMD->>Undo: INSERT INTO action_log
+    UI->>CMD: updateImageMetadata()
+    CMD->>DB: UPDATE images SET ...
+    UI->>UI: Store更新
+```
+
+### グループ管理
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant UI as フロントエンド
+    participant Rust as commands.rs
+    participant DB as SQLite
+
+    User->>UI: グループ作成
+    UI->>Rust: invoke('create_group')
+    Rust->>Rust: バリデーション
+    Rust->>DB: INSERT INTO groups
+    Rust-->>UI: グループID
+
+    User->>UI: 画像をグループに追加
+    UI->>Rust: invoke('add_images_to_group')
+    Rust->>DB: INSERT INTO image_groups (トランザクション)
+    Rust-->>UI: 成功
+```
+
+## 対応フォーマット
+
+| 種別 | 拡張子 |
+|------|--------|
+| 画像 | jpg, jpeg, png, gif, webp |
+| 動画 | mp4, webm, mov |
+
+## データベース
+
+ER図と詳細は [er-diagram.md](./er-diagram.md) を参照。
+
+コマンドリファレンスは [commands-reference.md](./commands-reference.md) を参照。

--- a/doc/commands-reference.md
+++ b/doc/commands-reference.md
@@ -1,0 +1,504 @@
+# Tauri コマンドリファレンス
+
+Image Gallery Manager で使用される全 Tauri コマンドの一覧。
+
+各コマンドは `commands.rs` で `#[tauri::command]` として定義され、`lib.rs` の `invoke_handler` に登録されている。
+フロントエンドからは `src/utils/tauri-commands.ts` のラッパー関数経由で呼び出す。
+
+---
+
+## DB管理（4コマンド）
+
+### `initialize_database`
+
+データベースを初期化（テーブル作成・マイグレーション実行）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn initialize_database() -> Result<String, String>` |
+| パラメータ | なし |
+| 戻り値 | `String` — 成功メッセージ |
+| TSラッパー | `initializeDatabase()` |
+
+### `get_database_path`
+
+データベースファイルの絶対パスを取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_database_path() -> Result<String, String>` |
+| パラメータ | なし |
+| 戻り値 | `String` — DBファイルパス |
+| TSラッパー | `getDatabasePath()` |
+
+### `backup_database`
+
+データベースファイルをタイムスタンプ付きでバックアップ。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn backup_database() -> Result<String, String>` |
+| パラメータ | なし |
+| 戻り値 | `String` — バックアップファイルパス |
+| TSラッパー | `backupDatabase()` |
+
+### `reset_database`
+
+データベースファイルとサムネイルディレクトリを削除。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn reset_database() -> Result<String, String>` |
+| パラメータ | なし |
+| 戻り値 | `String` — 成功メッセージ |
+| TSラッパー | `resetDatabase()` |
+
+---
+
+## ファイル操作（2コマンド）
+
+### `select_directory`
+
+OSのディレクトリ選択ダイアログを表示。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn select_directory(app: AppHandle) -> Result<Option<String>, String>` |
+| パラメータ | なし（AppHandleは自動注入） |
+| 戻り値 | `Option<String>` — 選択パス or null（キャンセル） |
+| TSラッパー | `selectDirectory()` |
+
+### `scan_directory`
+
+指定ディレクトリ内の画像・動画ファイルをスキャン。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn scan_directory(path: String) -> Result<Vec<ImageFileInfo>, String>` |
+| パラメータ | `path: String` — ディレクトリパス |
+| 戻り値 | `Vec<ImageFileInfo>` — ファイル情報の配列 |
+| TSラッパー | `scanDirectory(path)` |
+
+---
+
+## 動画処理（2コマンド）
+
+### `check_ffmpeg_available`
+
+ffmpegが利用可能かチェック。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn check_ffmpeg_available() -> Result<String, String>` |
+| パラメータ | なし |
+| 戻り値 | `String` — ffmpegパスとバージョン情報 |
+| TSラッパー | `checkFFmpegAvailable()` |
+| 定義場所 | `video_utils.rs` |
+
+### `generate_video_thumbnail`
+
+動画のサムネイル画像を生成（3秒地点、JPEG品質2）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn generate_video_thumbnail(video_path: String, image_id: i64) -> Result<String, String>` |
+| パラメータ | `video_path: String`, `image_id: i64` |
+| 戻り値 | `String` — サムネイルファイルパス |
+| TSラッパー | `generateVideoThumbnail(videoPath, imageId)` |
+| 定義場所 | `video_utils.rs` |
+
+---
+
+## グループ管理（8コマンド）
+
+### `create_group`
+
+グループを新規作成。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn create_group(input: CreateGroupInput) -> Result<i64, String>` |
+| パラメータ | `input: { name, description?, color?, representative_image_id? }` |
+| 戻り値 | `i64` — 作成されたグループID |
+| バリデーション | 名前1〜100文字、説明最大500文字、色はHEX形式 |
+| TSラッパー | `createGroup(input)` |
+
+### `get_all_groups`
+
+全グループを取得（画像数を含む）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_all_groups() -> Result<Vec<GroupData>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Vec<GroupData>` — グループ配列（created_at DESC） |
+| TSラッパー | `getAllGroups()` |
+
+### `update_group`
+
+グループ情報を更新（部分更新対応）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn update_group(input: UpdateGroupInput) -> Result<(), String>` |
+| パラメータ | `input: { id, name?, description?, color?, representative_image_id? }` |
+| 戻り値 | なし |
+| バリデーション | create_group と同じ + 代表画像がグループに属しているか確認 |
+| TSラッパー | `updateGroup(input)` |
+
+### `delete_group`
+
+グループを削除（CASCADE で image_groups も削除）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn delete_group(group_id: i64) -> Result<(), String>` |
+| パラメータ | `group_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `deleteGroup(groupId)` |
+
+### `add_images_to_group`
+
+複数画像をグループに追加（トランザクション使用）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn add_images_to_group(image_ids: Vec<i64>, group_id: i64) -> Result<(), String>` |
+| パラメータ | `image_ids: Vec<i64>`, `group_id: i64` |
+| 戻り値 | なし |
+| 備考 | INSERT OR IGNORE で重複を無視 |
+| TSラッパー | `addImagesToGroup(imageIds, groupId)` |
+
+### `remove_images_from_group`
+
+複数画像をグループから削除（トランザクション使用）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn remove_images_from_group(image_ids: Vec<i64>, group_id: i64) -> Result<(), String>` |
+| パラメータ | `image_ids: Vec<i64>`, `group_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `removeImagesFromGroup(imageIds, groupId)` |
+
+### `get_group_images`
+
+グループに所属する画像IDの配列を取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_group_images(group_id: i64) -> Result<Vec<i64>, String>` |
+| パラメータ | `group_id: i64` |
+| 戻り値 | `Vec<i64>` — 画像ID配列 |
+| TSラッパー | `getGroupImages(groupId)` |
+
+### `get_image_groups`
+
+画像が所属するグループIDの配列を取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_image_groups(image_id: i64) -> Result<Vec<i64>, String>` |
+| パラメータ | `image_id: i64` |
+| 戻り値 | `Vec<i64>` — グループID配列 |
+| TSラッパー | `getImageGroups(imageId)` |
+
+---
+
+## グループ詳細（2コマンド）
+
+### `get_group_by_id`
+
+グループIDから詳細情報を取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_group_by_id(group_id: i64) -> Result<GroupData, String>` |
+| パラメータ | `group_id: i64` |
+| 戻り値 | `GroupData` |
+| TSラッパー | `getGroupById(groupId)` |
+
+### `set_representative_image`
+
+グループの代表画像を設定（グループに属する画像のみ指定可能）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn set_representative_image(group_id: i64, image_id: Option<i64>) -> Result<(), String>` |
+| パラメータ | `group_id: i64`, `image_id: Option<i64>` |
+| 戻り値 | なし |
+| 備考 | `image_id: null` で代表画像を解除 |
+| TSラッパー | `setRepresentativeImage(groupId, imageId)` |
+
+---
+
+## コメント（3コマンド）
+
+### `add_group_comment`
+
+グループコメントを追加。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn add_group_comment(input: AddCommentInput) -> Result<i64, String>` |
+| パラメータ | `input: { group_id, comment }` |
+| 戻り値 | `i64` — 作成されたコメントID |
+| バリデーション | コメント1〜500文字 |
+| TSラッパー | `addGroupComment(input)` |
+
+### `get_group_comments`
+
+グループの全コメントを取得（新しい順）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_group_comments(group_id: i64) -> Result<Vec<GroupComment>, String>` |
+| パラメータ | `group_id: i64` |
+| 戻り値 | `Vec<GroupComment>` |
+| TSラッパー | `getGroupComments(groupId)` |
+
+### `delete_group_comment`
+
+グループコメントを削除。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn delete_group_comment(comment_id: i64) -> Result<(), String>` |
+| パラメータ | `comment_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `deleteGroupComment(commentId)` |
+
+---
+
+## マルチディレクトリ（6コマンド）
+
+### `add_directory`
+
+ディレクトリを追加し、既存画像のバックフィルを実行。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn add_directory(path: String) -> Result<DirectoryData, String>` |
+| パラメータ | `path: String` — ディレクトリ絶対パス |
+| 戻り値 | `DirectoryData` — 追加されたディレクトリ情報 |
+| 備考 | 既存の場合は再アクティブ化 |
+| TSラッパー | `addDirectory(path)` |
+
+### `remove_directory`
+
+ディレクトリを削除（画像データは保持、directory_id を NULL に）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn remove_directory(directory_id: i64) -> Result<(), String>` |
+| パラメータ | `directory_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `removeDirectory(directoryId)` |
+
+### `get_all_directories`
+
+全ディレクトリを取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_all_directories() -> Result<Vec<DirectoryData>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Vec<DirectoryData>` — created_at DESC |
+| TSラッパー | `getAllDirectories()` |
+
+### `set_directory_active`
+
+ディレクトリのアクティブ/非アクティブ状態を切り替え。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn set_directory_active(directory_id: i64, is_active: bool) -> Result<(), String>` |
+| パラメータ | `directory_id: i64`, `is_active: bool` |
+| 戻り値 | なし |
+| TSラッパー | `setDirectoryActive(directoryId, isActive)` |
+
+### `scan_single_directory`
+
+指定ディレクトリを再スキャン。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn scan_single_directory(directory_id: i64) -> Result<Vec<ImageFileInfo>, String>` |
+| パラメータ | `directory_id: i64` |
+| 戻り値 | `Vec<ImageFileInfo>` |
+| TSラッパー | `scanSingleDirectory(directoryId)` |
+
+### `scan_all_active_directories`
+
+全アクティブディレクトリをスキャン。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub async fn scan_all_active_directories() -> Result<Vec<ImageFileInfo>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Vec<ImageFileInfo>` |
+| TSラッパー | `scanAllActiveDirectories()` |
+
+---
+
+## Undo/Redo（5コマンド）
+
+### `log_action`
+
+アクションをログに記録（最大50件保持）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn log_action(action_type, target_table, target_id, old_value, new_value) -> Result<i64, String>` |
+| パラメータ | `action_type: String`, `target_table: String`, `target_id: i64`, `old_value: Option<String>`, `new_value: Option<String>` |
+| 戻り値 | `i64` — アクションID |
+| 備考 | 新規記録時に is_undone=1 のエントリを削除（redo履歴クリア） |
+| TSラッパー | `logAction(actionType, targetTable, targetId, oldValue, newValue)` |
+
+### `get_last_undoable_action`
+
+最新のundo可能なアクションを取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_last_undoable_action() -> Result<Option<ActionLogEntry>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Option<ActionLogEntry>` |
+| TSラッパー | `getLastUndoableAction()` |
+
+### `get_last_redoable_action`
+
+最新のredo可能なアクションを取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_last_redoable_action() -> Result<Option<ActionLogEntry>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Option<ActionLogEntry>` |
+| TSラッパー | `getLastRedoableAction()` |
+
+### `mark_action_undone`
+
+アクションをundo済みとしてマーク。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn mark_action_undone(action_id: i64) -> Result<(), String>` |
+| パラメータ | `action_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `markActionUndone(actionId)` |
+
+### `mark_action_redone`
+
+アクションをredo済みとしてマーク。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn mark_action_redone(action_id: i64) -> Result<(), String>` |
+| パラメータ | `action_id: i64` |
+| 戻り値 | なし |
+| TSラッパー | `markActionRedone(actionId)` |
+
+---
+
+## エクスポート/インポート（3コマンド）
+
+### `export_metadata_json`
+
+全メタデータをJSON形式でエクスポート（画像、グループ、メンバーシップ）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn export_metadata_json(output_path: String) -> Result<String, String>` |
+| パラメータ | `output_path: String` — 出力ファイルパス |
+| 戻り値 | `String` — 出力ファイルパス |
+| TSラッパー | `exportMetadataJson(outputPath)` |
+
+### `export_metadata_csv`
+
+画像メタデータをCSV形式でエクスポート。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn export_metadata_csv(output_path: String) -> Result<String, String>` |
+| パラメータ | `output_path: String` — 出力ファイルパス |
+| 戻り値 | `String` — 出力ファイルパス |
+| TSラッパー | `exportMetadataCsv(outputPath)` |
+
+### `import_metadata_json`
+
+JSONファイルからメタデータをインポート（file_path でマッチ）。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn import_metadata_json(input_path: String) -> Result<String, String>` |
+| パラメータ | `input_path: String` — 入力ファイルパス |
+| 戻り値 | `String` — インポート結果サマリー |
+| 備考 | 画像はfile_pathでマッチ更新、グループは名前でマッチ/新規作成 |
+| TSラッパー | `importMetadataJson(inputPath)` |
+
+---
+
+## ファイルウォッチャー（3コマンド）
+
+### `start_file_watcher`
+
+指定ディレクトリのファイル変更監視を開始。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn start_file_watcher(app: AppHandle, paths: Vec<String>) -> Result<(), String>` |
+| パラメータ | `paths: Vec<String>` — 監視ディレクトリパス配列 |
+| 戻り値 | なし |
+| 定義場所 | `commands.rs`（`watcher.rs` に委譲） |
+| TSラッパー | `startFileWatcher(paths)` |
+
+### `stop_file_watcher`
+
+ファイル監視を停止。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn stop_file_watcher(app: AppHandle) -> Result<(), String>` |
+| パラメータ | なし |
+| 戻り値 | なし |
+| TSラッパー | `stopFileWatcher()` |
+
+### `get_watched_directories`
+
+現在監視中のディレクトリパスを取得。
+
+| 項目 | 値 |
+|------|-----|
+| Rust関数 | `pub fn get_watched_directories(app: AppHandle) -> Result<Vec<String>, String>` |
+| パラメータ | なし |
+| 戻り値 | `Vec<String>` — 監視中パス配列 |
+| TSラッパー | `getWatchedDirectories()` |
+
+---
+
+## フロントエンド専用関数（tauri-commands.ts）
+
+以下の関数は Tauri コマンドではなく、`tauri-plugin-sql` で直接SQLiteにアクセスする。
+
+| 関数 | 説明 |
+|------|------|
+| `getAllImages()` | 全画像を取得（SELECT * FROM images） |
+| `getImagesByDirectoryId(directoryId)` | ディレクトリIDで画像をフィルタ取得 |
+| `updateImageMetadata(data)` | 画像メタデータを更新（rating, comment, tags, is_favorite） |
+| `selectAndAddDirectory()` | ダイアログ表示 → ディレクトリ追加のヘルパー |
+
+## コマンド数サマリー
+
+| カテゴリ | 数 |
+|----------|-----|
+| DB管理 | 4 |
+| ファイル操作 | 2 |
+| 動画処理 | 2 |
+| グループ管理 | 8 |
+| グループ詳細 | 2 |
+| コメント | 3 |
+| マルチディレクトリ | 6 |
+| Undo/Redo | 5 |
+| エクスポート/インポート | 3 |
+| ファイルウォッチャー | 3 |
+| **合計** | **38** |

--- a/doc/er-diagram.md
+++ b/doc/er-diagram.md
@@ -1,0 +1,132 @@
+# ER図 — データベース設計
+
+Image Gallery Manager の SQLite データベース設計。
+
+## ER図
+
+```mermaid
+erDiagram
+    directories {
+        INTEGER id PK "AUTOINCREMENT"
+        TEXT path UK "NOT NULL, ディレクトリ絶対パス"
+        TEXT name "NOT NULL, ディレクトリ名"
+        INTEGER is_active "DEFAULT 1"
+        TEXT last_scanned_at "最終スキャン日時"
+        INTEGER file_count "DEFAULT 0"
+        TEXT created_at "DEFAULT CURRENT_TIMESTAMP"
+    }
+
+    images {
+        INTEGER id PK "AUTOINCREMENT"
+        TEXT file_path UK "NOT NULL, ファイル絶対パス"
+        TEXT file_name "NOT NULL"
+        TEXT file_type "DEFAULT 'image' (image/video)"
+        TEXT comment "コメント"
+        TEXT tags "JSON配列"
+        INTEGER rating "DEFAULT 0 (0-5)"
+        INTEGER is_favorite "DEFAULT 0 (0/1)"
+        TEXT created_at "DEFAULT CURRENT_TIMESTAMP"
+        TEXT updated_at "DEFAULT CURRENT_TIMESTAMP"
+        REAL duration_seconds "動画の長さ(秒)"
+        INTEGER width "解像度(幅)"
+        INTEGER height "解像度(高さ)"
+        TEXT video_codec "ビデオコーデック"
+        TEXT audio_codec "オーディオコーデック"
+        TEXT thumbnail_path "サムネイルパス"
+        INTEGER directory_id FK "directories.id"
+    }
+
+    groups {
+        INTEGER id PK "AUTOINCREMENT"
+        TEXT name "NOT NULL"
+        TEXT description "最大500文字"
+        TEXT color "DEFAULT '#3b82f6' (HEX)"
+        INTEGER representative_image_id FK "images.id"
+        TEXT created_at "DEFAULT CURRENT_TIMESTAMP"
+        TEXT updated_at "DEFAULT CURRENT_TIMESTAMP"
+    }
+
+    image_groups {
+        INTEGER id PK "AUTOINCREMENT"
+        INTEGER image_id FK "NOT NULL, images.id"
+        INTEGER group_id FK "NOT NULL, groups.id"
+        TEXT added_at "DEFAULT CURRENT_TIMESTAMP"
+    }
+
+    group_comments {
+        INTEGER id PK "AUTOINCREMENT"
+        INTEGER group_id FK "NOT NULL, groups.id"
+        TEXT comment "NOT NULL, 最大500文字"
+        TEXT created_at "DEFAULT CURRENT_TIMESTAMP"
+    }
+
+    action_log {
+        INTEGER id PK "AUTOINCREMENT"
+        TEXT action_type "NOT NULL"
+        TEXT target_table "NOT NULL"
+        INTEGER target_id "NOT NULL"
+        TEXT old_value "旧値(JSON)"
+        TEXT new_value "新値(JSON)"
+        TEXT created_at "DEFAULT CURRENT_TIMESTAMP"
+        INTEGER is_undone "DEFAULT 0"
+    }
+
+    directories ||--o{ images : "1:N (ON DELETE SET NULL)"
+    images ||--o{ image_groups : "1:N (ON DELETE CASCADE)"
+    groups ||--o{ image_groups : "1:N (ON DELETE CASCADE)"
+    groups ||--o{ group_comments : "1:N (ON DELETE CASCADE)"
+    images |o--o| groups : "代表画像 (ON DELETE SET NULL)"
+```
+
+## リレーション詳細
+
+| 親テーブル | 子テーブル | 関係 | 外部キー | 削除時動作 |
+|-----------|-----------|------|---------|-----------|
+| `directories` | `images` | 1:N | `images.directory_id` | SET NULL |
+| `images` | `image_groups` | 1:N | `image_groups.image_id` | CASCADE |
+| `groups` | `image_groups` | 1:N | `image_groups.group_id` | CASCADE |
+| `groups` | `group_comments` | 1:N | `group_comments.group_id` | CASCADE |
+| `images` | `groups` | 0..1:1 | `groups.representative_image_id` | SET NULL |
+
+## インデックス一覧
+
+| テーブル | インデックス名 | カラム | 追加バージョン |
+|----------|---------------|--------|--------------|
+| `images` | `idx_file_path` | `file_path` | v1 |
+| `images` | `idx_file_name` | `file_name` | v1 |
+| `images` | `idx_file_type` | `file_type` | v2 |
+| `images` | `idx_is_favorite` | `is_favorite` | v3 |
+| `images` | `idx_duration` | `duration_seconds` | v4 |
+| `images` | `idx_resolution` | `width, height` | v4 |
+| `images` | `idx_images_directory_id` | `directory_id` | v7 |
+| `groups` | `idx_groups_name` | `name` | v5 |
+| `groups` | `idx_groups_created_at` | `created_at` | v5 |
+| `image_groups` | `idx_image_groups_image` | `image_id` | v5 |
+| `image_groups` | `idx_image_groups_group` | `group_id` | v5 |
+| `image_groups` | (UNIQUE) | `image_id, group_id` | v5 |
+| `group_comments` | `idx_group_comments_group` | `group_id` | v6 |
+| `group_comments` | `idx_group_comments_created_at` | `created_at` | v6 |
+| `directories` | `idx_directories_path` | `path` | v7 |
+| `directories` | `idx_directories_is_active` | `is_active` | v7 |
+| `action_log` | `idx_action_log_created_at` | `created_at` | v7 |
+| `action_log` | `idx_action_log_is_undone` | `is_undone` | v7 |
+
+## マイグレーション履歴
+
+| バージョン | 説明 | 追加Phase |
+|-----------|------|----------|
+| v1 | `images` テーブル作成（基本カラム + インデックス） | Phase 1 |
+| v2 | `file_type` カラム追加（画像/動画の判定） | Phase 2 |
+| v3 | `is_favorite` カラム追加（お気に入り機能） | Phase 2 |
+| v4 | 動画メタデータカラム追加（duration, width, height, codecs, thumbnail_path） | Phase 3 |
+| v5 | `groups` + `image_groups` テーブル追加（グループ管理） | Phase 4 |
+| v6 | `group_comments` テーブル追加（グループコメント機能） | Phase 5 |
+| v7 | `directories` + `action_log` テーブル追加、`images.directory_id` 追加 | Phase 6 |
+
+## DBファイルの場所
+
+```
+~/Library/Application Support/com.imagegallery/gallery.db
+```
+
+旧バージョン（v0.1.0以前）: `~/.image_gallery/gallery.db`（初回起動時に自動移行）


### PR DESCRIPTION
## 概要

Phase 7まで完了した全機能を反映し、プロジェクト全体を俯瞰するドキュメントを整備。
新規参加者やメンテナンス時の参照資料として、アーキテクチャ概要・ER図・コマンドリファレンスを新規作成。

## 変更内容

### 新規作成
- **`doc/architecture.md`** — アーキテクチャ概要（Mermaidシステム構成図・シーケンス図・コンポーネントツリー・状態管理・ルーティング）
- **`doc/er-diagram.md`** — ER図（Mermaid erDiagram、6テーブル）+ リレーション詳細 + インデックス一覧 + マイグレーション履歴(v1-v7)
- **`doc/commands-reference.md`** — 全38 Tauriコマンドのリファレンス（カテゴリ別、Rust関数/パラメータ/戻り値/TSラッパー）
- **`doc/11_phase7-completed.md`** — Phase 7完了報告（テスト基盤・タグオートコンプリート・タイムラインビュー）

### 更新
- **`README.md`** — Phase 4-7の機能反映、プロジェクト構成更新（サブディレクトリ反映）、テストコマンド追加、使い方にグループ/ディレクトリ/エクスポート操作手順追加、DBセクションをER図リンクに置換、ドキュメント一覧セクション追加

## テスト
- [ ] Mermaid図がGitHub上で正しくレンダリングされること
- [ ] ドキュメント間のリンク切れがないこと
- [ ] 既存の `CLAUDE.md` や `.claude/rules/` との重複・矛盾がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)