### PR TITLE
fix: グループ画面から戻る際のフリーズとclosed poolエラーを修正

### DIFF
--- a/src/components/GroupAlbumView.tsx
+++ b/src/components/GroupAlbumView.tsx
@@ -24,17 +24,16 @@ function GroupAlbumView() {
     setRepImageSelectionMode,
     showToast,
     updateGroup,
-    resetAllModes,
   } = useImageStore();
 
   const [group, setGroup] = useState<GroupData | null>(null);
   const [groupImageIds, setGroupImageIds] = useState<number[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // ページ遷移時にモード状態をクリア
+  // ページ遷移時にモード状態をクリア（依存配列を空にして1回だけ登録）
   useEffect(() => {
-    return () => { resetAllModes(); };
-  }, [resetAllModes]);
+    return () => { useImageStore.getState().resetAllModes(); };
+  }, []);
 
   // 代表画像をuseMemoで計算（パフォーマンス最適化）
   // allImages全体の変更ではなく、代表画像IDが変更された時のみ実質的に更新される

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -119,6 +119,8 @@ interface ImageStore {
 
   /** 選択されたディレクトリID（nullは全画像表示） */
   selectedDirectoryId: number | null;
+  /** 最後に画像をロードしたディレクトリID（再フェッチスキップ判定用） */
+  _lastLoadedDirectoryId: number | null;
 
   /** 画像データの配列を設定します */
   setImages: (images: ImageData[]) => void;
@@ -254,6 +256,7 @@ export const useImageStore = create<ImageStore>()(
       repImageSelectionGroupId: null,
 
       selectedDirectoryId: null,
+      _lastLoadedDirectoryId: null,
 
       setImages: (images) => set({ images }),
       setCurrentDirectory: (path) => set({ currentDirectory: path }),


### PR DESCRIPTION
## Summary

- `Database.load()` が返す共有接続プールを各関数の `finally` ブロックで `db.close()` していたことで、画面遷移時に "attempted to acquire a connection on a closed pool" エラーが発生していた問題を修正
- `MainGallery` マウント時に毎回 DB から全画像を再フェッチしていたことによるフリーズを、ストアに既に画像がある場合はスキップすることで解消
- `GroupAlbumView` アンマウント時の `resetAllModes` の依存配列を修正し、不要な再レンダリングを防止

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `src/utils/tauri-commands.ts` | `getDatabase()` をシングルトン化、全6箇所の `db.close()` を削除、`resetDatabase()` 時に `dbInstance` をクリア |
| `src/components/MainGallery.tsx` | 画像がストアに既にあり同一ディレクトリの場合は DB 再フェッチをスキップ |
| `src/components/GroupAlbumView.tsx` | `resetAllModes` を `useImageStore.getState()` 経由で呼び出し、依存配列を `[]` に変更 |
| `src/store/imageStore.ts` | `_lastLoadedDirectoryId` を追加（再フェッチスキップ判定用） |

## Test plan

- [ ] グループ画面 → メイン画面に戻る操作を繰り返し、フリーズしないことを確認
- [ ] 上記操作で "closed pool" エラーが表示されないことを確認
- [ ] サイドバーでディレクトリを切り替えた後にグループ経由で戻り、正しいディレクトリの画像が表示されることを確認
- [ ] DB リセット後に再起動して正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)